### PR TITLE
FIX: modify page route path to adjust RESTful url naming rule

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -37,10 +37,6 @@ const Home = () => {
   }, [userGoalsData]);
 
   const navigate = useNavigate();
-  const handleAddGoal = () => {
-    navigate('/goal/add');
-  };
-
   return (
     <Wrapper>
       <UserProfile />
@@ -51,7 +47,7 @@ const Home = () => {
           goals?.map((goal) => <MyGoalCard key={goal.id} goal={goal} />)
         )}
       </CardList>
-      <AddGoalBtn onClick={handleAddGoal}>
+      <AddGoalBtn onClick={() => navigate('/goals/post')}>
         <SVGIcon viewBox='0 0 24 24'>
           <path fill='#f18529' d='M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z' />
         </SVGIcon>

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -3,10 +3,10 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import Header from './Header';
 import Home from '../pages/Home';
-import AddGoal from '../pages/AddGoal';
+import PostGoal from '../pages/PostGoal';
 import DetailGoal from '../pages/DetailGoal';
-import Navigation from './Navigation';
 import GroupGoals from '../pages/GroupGoals';
+import Navigation from './Navigation';
 
 const Router = () => {
   return (
@@ -14,8 +14,8 @@ const Router = () => {
       <Header />
       <Routes>
         <Route path='/' element={<Home />} />
-        <Route path='/goal/add' element={<AddGoal />} />
-        <Route path='/goal/:id' element={<DetailGoal />} />
+        <Route path='/goals/post' element={<PostGoal />} />
+        <Route path='/goals/:id' element={<DetailGoal />} />
         <Route path='/goals/search' element={<GroupGoals />} />
       </Routes>
       <Navigation />


### PR DESCRIPTION
# 페이지 경로 RESTful url 네이밍 규칙에 맞춰 수정 (#24)
## 변경 사항
* `src/shared/Routes.tsx`: 페이지 url path를 복수형, 명사만 사용하도록 수정
* `src/pages/Home.tsx`: 변경된 목표 추가 페이지 url path 적용