### PR TITLE
FEAT: add atomic components

### DIFF
--- a/src/components/common/elem/DateSelectBox.tsx
+++ b/src/components/common/elem/DateSelectBox.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface DateSelectBoxProps {
+  // date input box value should be 'YYYY-MM-DD' format
+  value: string;
+  min: string;
+  max: string;
+  onChange: (e: React.FormEvent<HTMLInputElement>) => void;
+}
+
+function DateSelectBox({ value, min, max, onChange }: DateSelectBoxProps) {
+  return (
+    <DateSelect
+      type='date'
+      value={value}
+      min={min}
+      max={max}
+      onChange={onChange}></DateSelect>
+  );
+}
+
+const DateSelect = styled.input`
+  padding: 0 10px;
+  width: calc(100% - 20px);
+  height: 100%;
+  font: ${(props) => props.theme.captionC3};
+  border: 1px solid black;
+`;
+
+export default DateSelectBox;

--- a/src/components/common/elem/Icon.tsx
+++ b/src/components/common/elem/Icon.tsx
@@ -1,0 +1,13 @@
+import React, { FunctionComponent, PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+const Icon: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  return <SVGIcon viewBox='0 0 24 24'>{children}</SVGIcon>;
+};
+
+const SVGIcon = styled.svg`
+  width: 1rem;
+  height: 1rem;
+`;
+
+export default Icon;

--- a/src/components/common/elem/InputBox.tsx
+++ b/src/components/common/elem/InputBox.tsx
@@ -5,21 +5,33 @@ interface InputBoxProps {
   value: string | number;
   placeholder: string;
   onChangeHandler: (e: React.FormEvent<HTMLInputElement>) => void;
+  borderRadius?: string;
 }
 
-const InputBox = ({ placeholder, value, onChangeHandler }: InputBoxProps) => {
+const InputBox = ({
+  placeholder,
+  value,
+  onChangeHandler,
+  borderRadius,
+}: InputBoxProps) => {
   return (
-    <Input value={value} placeholder={placeholder} onChange={onChangeHandler} />
+    <Input
+      value={value}
+      placeholder={placeholder}
+      onChange={onChangeHandler}
+      borderRadius={borderRadius}
+    />
   );
 };
 
-const Input = styled.input`
+const Input = styled.input<{ borderRadius?: string }>`
   padding: 0;
   width: 100%;
-  height: 30px;
+  height: 100%;
   border: 1px solid black;
   text-indent: 10px;
   font: ${(props) => props.theme.captionC3};
+  border-radius: ${(props) => props.borderRadius};
 `;
 
 export default InputBox;

--- a/src/components/common/elem/InputBox.tsx
+++ b/src/components/common/elem/InputBox.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface InputBoxProps {
+  value: string | number;
+  placeholder: string;
+  onChangeHandler: (e: React.FormEvent<HTMLInputElement>) => void;
+}
+
+const InputBox = ({ placeholder, value, onChangeHandler }: InputBoxProps) => {
+  return (
+    <Input value={value} placeholder={placeholder} onChange={onChangeHandler} />
+  );
+};
+
+const Input = styled.input`
+  padding: 0;
+  width: 100%;
+  height: 30px;
+  border: 1px solid black;
+  text-indent: 10px;
+  font: ${(props) => props.theme.captionC3};
+`;
+
+export default InputBox;

--- a/src/components/common/elem/RadioSelectBox.tsx
+++ b/src/components/common/elem/RadioSelectBox.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface RadioSelectBoxProps {
+  options: Array<string>;
+  selected?: string;
+  onChangeHandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+function RadioSelectBox({
+  options,
+  selected,
+  onChangeHandler,
+}: RadioSelectBoxProps) {
+  return (
+    <Wrapper>
+      {options.map((option) => (
+        <React.Fragment key={option}>
+          <input
+            type='radio'
+            value={option}
+            checked={selected === option}
+            onChange={onChangeHandler}
+          />
+          <RadioLabel>{option}</RadioLabel>
+        </React.Fragment>
+      ))}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  padding: 10px 0;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 20px;
+`;
+
+const RadioLabel = styled.span`
+  font: ${(props) => props.theme.captionC3};
+`;
+
+export default RadioSelectBox;

--- a/src/components/common/elem/ValidateMsg.tsx
+++ b/src/components/common/elem/ValidateMsg.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface ValidateMsgProps {
+  msg: string;
+  type: 'error' | 'success';
+}
+
+const ValidateMsg = ({ msg, type }: ValidateMsgProps) => {
+  return <Msg type={type}>{msg}</Msg>;
+};
+
+const Msg = styled.p<{ type: 'error' | 'success' }>`
+  font: ${(props) => props.theme.captionC3};
+  color: ${(props) => (props.type === 'error' ? 'red' : 'blue')};
+`;
+
+export default ValidateMsg;

--- a/src/components/goal/GroupGoalCards.tsx
+++ b/src/components/goal/GroupGoalCards.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { IUserGoal } from '../../interfaces/interfaces';
 
 import { dDayCalculator } from '../../utils/dDayCalculator';
-import { dateStringTranslator } from '../../utils/dateStringTranslator';
+import { dateStringTranslator } from '../../utils/dateTranslator';
 
 const GroupGoalCards = ({ goal }: { goal: IUserGoal }) => {
   const navigate = useNavigate();

--- a/src/components/tag/HashTag.tsx
+++ b/src/components/tag/HashTag.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Icon from '../common/elem/Icon';
+
+interface HashTagProps {
+  tag: IHashTag;
+  removeHandler: (tag: IHashTag) => void | null;
+}
+
+export interface IHashTag {
+  content: string;
+  bgColor: string;
+}
+
+const HashTag = React.memo(function HashTag({
+  tag: { content, bgColor },
+  removeHandler,
+}: HashTagProps) {
+  return (
+    <Tag bgColor={bgColor}>
+      {`#${content}`}
+      {removeHandler === null ? (
+        <></>
+      ) : (
+        <DeleteButton onClick={() => removeHandler({ content, bgColor })}>
+          <Icon>
+            <path
+              fill='#e4f7ea'
+              d='M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z'
+            />
+          </Icon>
+        </DeleteButton>
+      )}
+    </Tag>
+  );
+});
+
+const Tag = styled.div<{ bgColor: string }>`
+  padding: 12px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  font: ${(props) => props.theme.captionC2};
+  border-radius: 16px;
+  background-color: ${(props) => props.bgColor};
+`;
+
+const DeleteButton = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 1rem;
+  height: 1rem;
+  background-color: transparent;
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+export default HashTag;

--- a/src/hooks/useDateInput.tsx
+++ b/src/hooks/useDateInput.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { dateISOStringDateTranslator } from '../utils/dateTranslator';
+interface useDateInputProps {
+  startDate: Date;
+  minDays: number;
+  maxDays: number;
+}
+
+const useDateInput = ({ startDate, minDays, maxDays }: useDateInputProps) => {
+  const getFutureDate = (afterDays: number) => {
+    const funtureDate = new Date().setDate(startDate.getDate() + afterDays);
+    return dateISOStringDateTranslator(new Date(funtureDate));
+  };
+
+  const [minDate, setMinDate] = useState<string>(getFutureDate(minDays));
+  const [maxDate, setMaxDate] = useState<string>(getFutureDate(maxDays));
+  const [value, setValue] = useState<string>(minDate);
+
+  const onChange = (e: React.FormEvent<HTMLInputElement>) => {
+    console.log('selected time', e.currentTarget.value);
+    setValue(e.currentTarget.value);
+  };
+
+  useEffect(() => {
+    if (new Date().getHours() === 0) {
+      setMinDate(getFutureDate(minDays));
+      setMaxDate(getFutureDate(maxDays));
+      setValue(minDate);
+    }
+  }, [new Date().getHours()]);
+
+  return { minDate, maxDate, value, onChange };
+};
+
+export default useDateInput;

--- a/src/hooks/useNumInput.tsx
+++ b/src/hooks/useNumInput.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+
+interface useNumInputProps {
+  initValue: number;
+  min: number;
+  max: number;
+  type: '목표 금액' | '인원';
+}
+
+const useNumInput = ({ initValue, min, max, type }: useNumInputProps) => {
+  const [value, setValue] = useState(initValue);
+  const [errMsg, setErrMsg] = useState('');
+
+  const [isValidated, setIsValidated] = useState(false);
+  const validate = () => {
+    if (value < min) {
+      switch (type) {
+        case '목표 금액':
+          console.log('error');
+          setErrMsg(`${type} 최소값은 ${min.toLocaleString()} 원 입니다.`);
+          return;
+        case '인원':
+          setErrMsg(`${type} 최소값은 ${max} 명 입니다.`);
+          return;
+      }
+    }
+
+    if (value > max) {
+      switch (type) {
+        case '목표 금액':
+          setErrMsg(`${type} 최대값은 ${max.toLocaleString()} 원 입니다.`);
+          return;
+        case '인원':
+          setErrMsg(`${type} 최대값은 ${max} 명 입니다.`);
+          return;
+      }
+    }
+
+    setErrMsg('');
+  };
+
+  useEffect(() => {
+    if (!isValidated) return;
+    validate();
+  }, [value]);
+
+  const onChange = (e: React.FormEvent<HTMLInputElement>) => {
+    if (!isValidated) setIsValidated(true);
+    setValue(Number(e.currentTarget.value.replaceAll(',', '')));
+  };
+
+  const reset = () => setValue(initValue);
+
+  return { value, errMsg, onChange, reset };
+};
+
+export default useNumInput;

--- a/src/hooks/useTxtInput.tsx
+++ b/src/hooks/useTxtInput.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+interface useInputProps {
+  initValue: string;
+  minLength: number;
+  maxLength: number;
+  type: '제목' | '설명' | '해시태그';
+}
+
+const useTxtInput = ({
+  initValue,
+  minLength,
+  maxLength,
+  type,
+}: useInputProps) => {
+  const [value, setValue] = useState(initValue);
+  const [errMsg, setErrMsg] = useState('');
+
+  const [isValidated, setIsValidated] = useState(false);
+  const maxValidate = () => {
+    if (value.length > maxLength) {
+      setErrMsg(`${type} 길이는 최대 ${maxLength}자 입니다.`);
+      setValue((prev) => prev.slice(0, maxLength + 1));
+      return;
+    }
+
+    setErrMsg('');
+  };
+
+  const minValidate = () => {
+    if (minLength === 0) return;
+    if (value.length < minLength) {
+      setErrMsg(`${type} 길이는 최소 ${minLength}자 입니다.`);
+      return;
+    }
+
+    setErrMsg('');
+  };
+
+  useEffect(() => {
+    if (!isValidated) return;
+    minValidate();
+    maxValidate();
+  }, [value]);
+
+  const onChange = (e: React.FormEvent<HTMLInputElement>) => {
+    if (!isValidated) setIsValidated(true);
+    setValue(e.currentTarget.value);
+  };
+
+  const reset = () => setValue(initValue);
+
+  return { value, errMsg, onChange, reset };
+};
+
+export default useTxtInput;

--- a/src/utils/dateTranslator.ts
+++ b/src/utils/dateTranslator.ts
@@ -1,3 +1,5 @@
+// dateStringTranslator returns date to formatted string
+// ex.'YYYY/MM/DD(Day)'
 export const dateStringTranslator = (targetDate: Date) => {
   const dayIndex = (day: number) => {
     switch (day) {

--- a/src/utils/dateTranslator.ts
+++ b/src/utils/dateTranslator.ts
@@ -1,4 +1,4 @@
-// dateStringTranslator returns date to formatted string
+// dateStringTranslator returns date to formatted string timestamp
 // ex.'YYYY/MM/DD(Day)'
 export const dateStringTranslator = (targetDate: Date) => {
   const dayIndex = (day: number) => {
@@ -40,8 +40,10 @@ export const dateStringTranslator = (targetDate: Date) => {
   return endDateIndicator;
 };
 
-// dateISOStringDateTranslator returns date to ISO formatted string
+// dateISOStringDateTranslator returns date to local ISO formatted string timestamp
 // ex. 'YYYY-MM-DD'
 export const dateISOStringDateTranslator = (date: Date) => {
-  return date.toISOString().split('T')[0];
+  const localTimeOffset = new Date().getTimezoneOffset() * 60000;
+  const localDate = date.getTime() - localTimeOffset;
+  return new Date(localDate).toISOString().split('T')[0];
 };

--- a/src/utils/dateTranslator.ts
+++ b/src/utils/dateTranslator.ts
@@ -39,3 +39,9 @@ export const dateStringTranslator = (targetDate: Date) => {
 
   return endDateIndicator;
 };
+
+// dateISOStringDateTranslator returns date to ISO formatted string
+// ex. 'YYYY-MM-DD'
+export const dateISOStringDateTranslator = (date: Date) => {
+  return date.toISOString().split('T')[0];
+};


### PR DESCRIPTION
# 공통 atomic 컴포넌트 구현 (#18)
## 구현 상세
* `src/components/`
  * `common/elem/`
    * `Icon.tsx`: svg path tag를 자식 컴포넌트로 받아 가로, 세로 `1rem` 크기의 아이콘을 반환하는 컴포넌트 구현
    * `InputBox.tsx`: `value`, `placeholder`, `onChangeHandler`를 props로 받아 input을 반환하는 컴포넌트 구현
    * `ValidateMsg.tsx`: 보여주고자 하는 string 타입의 `msg` 내용과 `error`, `success` 둘 중 하나인 `type`을 props로 받아 성공, 실패의 경우의 검증 메세지를 반환하는 컴포넌트 구현
    * `RadioSelectBox.tsx`: `Array<string>`타입의 `options`와 `string`타입의 `selected`(선택된 value), `onChange` 이벤트 핸들러 함수를 받아 여러 옵션 중 한가지를 선택하는 옵션 리스트를 반환하는 컴포넌트 구현
    * `DateSelectBox.tsx`: `string` 타입의 `value`, `min`, `max` 값과 `onChange` 이벤트 핸들러 함수를 받아 날짜를 선택하는 input 태그를 반환하는 컴포넌트 구현
  * `tag`
    * `HashTag.tsx`: string 타입의 `content`, `bgColor`를 가진 `IHashTag` 타입의 `tag` 와 태그 삭제 기능을 하는 `removeHandler`를 props로 받아 하나의 해쉬태그를 반환하는 컴포넌트 구현
* `src/hooks/`
  * `useNumInput.tsx`: `number` 타입의 값을 input으로 입력받고 최소, 최대값 validate를 하는 hook 구현
  * `useTxtInput.tsx`: `string` 타입의 값을 input으로 입력받고 최소, 최대 길이 validate를 하는 hook 구현  
  * `useDateInput.tsx`: `Date` 타입의 시작 일자와 `number` 타입의 최소 기간, 최대 기간 값을 받아 시간 입력 input의 최소값, 최대값, 변경되는 사용자의 입력값을 관리하는 hook 구현

## 변경 사항
* `src/utils`
  * `dateTranslator.ts`: `Date` 타입의 시간을 받아 ISO 포맷의 해당 시간의 'YYYY-MM-DD' 값을 `string` 타입으로 반환하는 함수 추가