### PR TITLE
FEAT: add modal box atomic component

### DIFF
--- a/src/components/common/elem/ModalBox.tsx
+++ b/src/components/common/elem/ModalBox.tsx
@@ -1,0 +1,69 @@
+import React, { FunctionComponent } from 'react';
+import styled from 'styled-components';
+
+import Icon from './Icon';
+
+interface ModalBoxProps {
+  title: string;
+  closeHandler: () => void;
+  children: React.ReactNode;
+}
+
+const ModalBox: FunctionComponent<ModalBoxProps> = ({
+  title,
+  closeHandler,
+  children,
+}) => {
+  return (
+    <Modal>
+      <ContentWrapper>
+        <Button onClick={closeHandler}>
+          <Icon>
+            <path
+              fill='#5fcf8a'
+              d='M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z'
+            />
+          </Icon>
+        </Button>
+        <Title>{title}</Title>
+        <Content>{children}</Content>
+      </ContentWrapper>
+    </Modal>
+  );
+};
+
+const Modal = styled.div`
+  padding: 5%;
+  width: 80%;
+  background-color: white;
+`;
+
+const ContentWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const Button = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const Title = styled.div`
+  font: ${(props) => props.theme.headingH4};
+`;
+
+const Content = styled.div`
+  padding: 20px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+  font: ${(props) => props.theme.parag};
+`;
+
+export default ModalBox;


### PR DESCRIPTION
# 모달창 공통 컴포넌트 구현 (#20)
## 구현 상세
* `src/components/common/elem/ModalBox.tsx`: `string` 타입의 모달창 제목, 모달창 닫기 함수, 모달창에 표시될 내용인 자식 element를 props로 받는 모달창 공통 컴포넌트 구현
