### PR TITLE
FIX: modify text input hook to validate value with regexp

### DIFF
--- a/src/hooks/useTxtInput.tsx
+++ b/src/hooks/useTxtInput.tsx
@@ -4,7 +4,15 @@ interface useInputProps {
   initValue: string;
   minLength: number;
   maxLength: number;
-  type: '제목' | '설명' | '해시태그';
+  type:
+    | '제목'
+    | '설명'
+    | '해시태그'
+    | '계좌번호'
+    | '계좌 비밀번호'
+    | '인터넷 뱅킹 아이디'
+    | '인터넷 뱅킹 비밀번호';
+  regExp?: RegExp;
 }
 
 const useTxtInput = ({
@@ -12,6 +20,7 @@ const useTxtInput = ({
   minLength,
   maxLength,
   type,
+  regExp,
 }: useInputProps) => {
   const [value, setValue] = useState(initValue);
   const [errMsg, setErrMsg] = useState('');
@@ -21,26 +30,46 @@ const useTxtInput = ({
     if (value.length > maxLength) {
       setErrMsg(`${type} 길이는 최대 ${maxLength}자 입니다.`);
       setValue((prev) => prev.slice(0, maxLength + 1));
-      return;
+      return false;
     }
 
-    setErrMsg('');
+    return true;
   };
 
   const minValidate = () => {
-    if (minLength === 0) return;
+    if (minLength === 0) return true;
     if (value.length < minLength) {
       setErrMsg(`${type} 길이는 최소 ${minLength}자 입니다.`);
-      return;
+      return false;
     }
 
-    setErrMsg('');
+    return true;
+  };
+
+  const regExpValidate = () => {
+    if (!regExp) return true;
+    const isValid = regExp.test(value);
+    if (!isValid) {
+      setErrMsg(`${type}의 형식에 맞지 않는 값 입니다.`);
+      return false;
+    }
+
+    return true;
+  };
+
+  const validate = () => {
+    const isMinValid = minValidate();
+    const isMaxValid = maxValidate();
+    const isRegExpValid = regExpValidate();
+
+    if (isMinValid && isMaxValid && isRegExpValid) {
+      setErrMsg('');
+    }
   };
 
   useEffect(() => {
     if (!isValidated) return;
-    minValidate();
-    maxValidate();
+    validate();
   }, [value]);
 
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {


### PR DESCRIPTION
# text input hook 수정
## 변경 사항
* `src/hooks/useTxtInput.tsx`: 
  1. props 수정: `type`에 종류 추가 및 `RegExp` 타입의 `regExp`을 받아 정규식 검사를 할 수 있도록 수정
  2. validate 함수의 `boolean` response 추가: 서로 다른 validate가 하나의 `errMsg` 상태를 공유하므로, 모든 validate가 통과되었을 때에 `errMsg`를 초기화 할 수 있도록 함