### PR TITLE
FIX: modify input box atomic component to have password type

### DIFF
--- a/src/components/common/elem/InputBox.tsx
+++ b/src/components/common/elem/InputBox.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface InputBoxProps {
+  type: 'text' | 'password';
   value?: string | number;
   placeholder?: string;
   onChangeHandler?: (e: React.FormEvent<HTMLInputElement>) => void;
@@ -10,14 +11,16 @@ interface InputBoxProps {
 }
 
 const InputBox = ({
-  placeholder,
+  type,
   value,
+  placeholder,
   onChangeHandler,
   onKeyPressHandler,
   borderRadius,
 }: InputBoxProps) => {
   return (
     <Input
+      type={type}
       value={value}
       placeholder={placeholder}
       onChange={onChangeHandler}


### PR DESCRIPTION
# input box 공통 컴포넌트 props 수정
## 변경 사항
* `src/components/common/elem/InputBox.tsx`: input type을 `'text'`, `'password'` 둘 중 하나를 받아, `'password'`인 경우 데이터를 화면에서 숨길 수 있도록 수정