### PR TITLE
Feat: add text button & caption c3 text box atomic components

### DIFF
--- a/src/components/common/elem/C3TextBox.tsx
+++ b/src/components/common/elem/C3TextBox.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const C3TextBox = ({ text }: { text: string }) => {
+  return <TextBox>{text}</TextBox>;
+};
+
+const TextBox = styled.div`
+  font: ${(props) => props.theme.captionC3};
+`;
+
+export default C3TextBox;

--- a/src/components/common/elem/TextButton.tsx
+++ b/src/components/common/elem/TextButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface TextButtonProps {
+  text: string;
+  onClickHandler: () => void;
+  isDisabled?: boolean;
+}
+
+const TextButton = ({ text, onClickHandler, isDisabled }: TextButtonProps) => {
+  return (
+    <Button disabled={isDisabled} disable={isDisabled} onClick={onClickHandler}>
+      <TextWrapper disable={isDisabled}>{text}</TextWrapper>
+    </Button>
+  );
+};
+
+const Button = styled.button<{ disable?: boolean }>`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  border-radius: 96px;
+  background-color: ${(props) => (props.disable ? props.theme.gray300 : props.theme.primaryMain)};
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const TextWrapper = styled.div<{ disable?: boolean }>`
+  padding: 10px 0;
+  font: ${(props) => props.theme.paragraphP3M};
+  color: ${(props) => (props.disable ? 'black' : 'white')};
+`;
+
+export default TextButton;


### PR DESCRIPTION
# 공통 컴포넌트 추가
## 구현 상세
* `src/components/common/elem/`
  * `C3TextBox.tsx`: caption c3의 font를 사용하는 텍스트 상자 컴포넌트 구현
  * `TextButton.tsx`: `string` 타입의 텍스트를 받아 버튼에 표시하는 버튼 컴포넌트 구현