### PR TITLE
FEAT: add user detail page

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -114,6 +114,45 @@ export const userAPI = {
     // };
     return data;
   },
+  getUserBadges: async (userId: number) => {
+    const { data } = await tokenClient.get(`/users/${userId}/badges`);
+    // const data = [
+    //   {
+    //     title: '첫 목표 생성',
+    //     description: '처음 목표를 추가하면 획득할 수 있는 뱃지입니다.',
+    //     isObtained: true,
+    //   },
+    //   {
+    //     title: '첫 목표 달성',
+    //     description:
+    //       '마감 기한까지 목표 금액을 100% 달성하면 획득할 수 있는 뱃지입니다.',
+    //     isObtained: true,
+    //   },
+    //   {
+    //     title: '첫 그룹 참여',
+    //     description: '처음 그룹 목표에 참여하면 획득할 수 있는 뱃지입니다.',
+    //     isObtained: true,
+    //   },
+    //   {
+    //     title: '첫 그룹 모집',
+    //     description: '처음 그룹 목표를 모집하면 획득할 수 있는 뱃지입니다.',
+    //     isObtained: true,
+    //   },
+    //   {
+    //     title: '첫 그룹 목표 100% 달성',
+    //     description:
+    //       '그룹 목표에서 마감 기한까지 목표 금액을 100% 달성하면 획득할 수 있는 뱃지입니다.',
+    //     isObtained: true,
+    //   },
+    //   {
+    //     title: '3회 연속 도달',
+    //     description:
+    //       '목표 금액 100% 달성을 3번 연속하면 획득할 수 있는 뱃지입니다.',
+    //     isObtained: true,
+    //   },
+    // ];
+    return data;
+  },
 };
 
 export const goalApi = {

--- a/src/components/badge/MyFilteredBadges.tsx
+++ b/src/components/badge/MyFilteredBadges.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { useQuery } from 'react-query';
+import styled from 'styled-components';
+
+import BadgeBox from '../common/elem/BadgeBox';
+
+import { userAPI } from '../../apis/client';
+
+import { userInfo } from '../../recoil/atoms';
+
+import { IBadge } from '../../interfaces/interfaces';
+
+const MyFilteredBadges = () => {
+  const { id } = useRecoilValue(userInfo);
+  const [badges, setBadges] = useState<Array<IBadge>>([
+    { title: '뱃지', description: '' },
+  ]);
+  const { isLoading, data } = useQuery<Array<IBadge>>('userBadges', () =>
+    userAPI.getUserBadges(id)
+  );
+
+  useEffect(() => {
+    if (!data) return;
+    setBadges(data);
+  }, [data]);
+
+  return (
+    <Wrapper>
+      {isLoading || !badges ? (
+        <>데이터를 불러오는 중입니다</>
+      ) : (
+        <Row>
+          {badges.map((badge) => (
+            <BadgeBox key={badge.title}></BadgeBox>
+          ))}
+        </Row>
+      )}
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+`;
+
+const Row = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  row-gap: 20px;
+  column-gap: 35px;
+  flex-wrap: wrap;
+`;
+
+export default MyFilteredBadges;

--- a/src/components/common/elem/BadgeBox.tsx
+++ b/src/components/common/elem/BadgeBox.tsx
@@ -1,0 +1,14 @@
+import React, { FunctionComponent, PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+const BadgeBox: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  return <Badge>{children}</Badge>;
+};
+
+const Badge = styled.div`
+  width: 100px;
+  height: 100px;
+  background-color: ${(props) => props.theme.gray300};
+`;
+
+export default BadgeBox;

--- a/src/components/goal/MyFilteredGoals.tsx
+++ b/src/components/goal/MyFilteredGoals.tsx
@@ -1,0 +1,208 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+import StateGoalCard from './StateGoalCard';
+
+import { IGoal } from '../../interfaces/interfaces';
+
+interface MyFilteredGoalsProps {
+  isOwner: boolean;
+  goals: Array<IGoal>;
+}
+
+enum FilterType {
+  success,
+  fail,
+  recruiting,
+  none,
+}
+
+const filters = [FilterType.success, FilterType.fail, FilterType.recruiting];
+
+const filterKR = (filterType: FilterType) => {
+  switch (filterType) {
+    case FilterType.success:
+      return '달성';
+    case FilterType.fail:
+      return '미달성';
+    case FilterType.recruiting:
+      return '모집중';
+    default:
+      return '';
+  }
+};
+
+const MyFilteredGoals = ({ isOwner, goals }: MyFilteredGoalsProps) => {
+  const [initialGoals, setInitialGoals] = useState<Array<IGoal>>([...goals]);
+  const [filteredGoals, setFilteredGoals] = useState<Array<IGoal>>([...goals]);
+  const [filterType, setFilterType] = useState<FilterType>(FilterType.none);
+  const handleFilterType = (type: FilterType) => {
+    setFilterType((prev) => {
+      if (prev === type) return FilterType.none;
+      return type;
+    });
+  };
+
+  useEffect(() => {
+    setInitialGoals([...goals]);
+  }, []);
+
+  useEffect(() => {
+    setFilteredGoals(() => {
+      const goals = [...initialGoals];
+
+      const filtered = goals.filter((goal) => {
+        switch (filterType) {
+          case FilterType.success:
+            return (
+              new Date(goal.startDate).getTime() < new Date().getTime() &&
+              goal.attainment === 100
+            );
+          case FilterType.fail:
+            return (
+              new Date(goal.startDate).getTime() < new Date().getTime() &&
+              goal.attainment < 100
+            );
+          case FilterType.recruiting:
+            return new Date(goal.startDate).getTime() > new Date().getTime();
+          case FilterType.none:
+            return goal;
+        }
+      });
+
+      return filtered;
+    });
+  }, [filterType]);
+
+  const [orderType, setOrderType] = useState<'asc' | 'desc'>('desc');
+  const handleOrderType = () => {
+    setOrderType((prev) => {
+      if (prev === 'asc') return 'desc';
+      return 'asc';
+    });
+  };
+
+  useEffect(() => {
+    setFilteredGoals((prev) => {
+      const prevGoals = [...prev];
+      prevGoals.sort((a, b) => {
+        if (orderType === 'asc') {
+          return (
+            new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+          );
+        }
+
+        return (
+          new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
+        );
+      });
+      return prevGoals;
+    });
+  }, [orderType]);
+  return (
+    <Wrapper>
+      <TopContent>
+        <Content>
+          <Total>{`전체 ${goals.length}개`}</Total>
+          <OrderButton onClick={handleOrderType}>
+            {orderType === 'desc' ? '최신순' : '과거순'}
+          </OrderButton>
+        </Content>
+        {isOwner ? (
+          <FiltersBox>
+            {filters.map((filter) => (
+              <FilterButton
+                key={filter}
+                selected={filterType === filter}
+                onClick={() => handleFilterType(filter)}>
+                {filterKR(filter)}
+              </FilterButton>
+            ))}
+          </FiltersBox>
+        ) : (
+          <></>
+        )}
+      </TopContent>
+      <BottomContent>
+        {filteredGoals.length === 0 ? (
+          <EmptyInfo>{`아직 ${filterKR(
+            filterType
+          )} 목표가 없습니다`}</EmptyInfo>
+        ) : (
+          filteredGoals.map((goal, idx) => (
+            <StateGoalCard key={idx} goal={goal} />
+          ))
+        )}
+      </BottomContent>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+`;
+
+const TopContent = styled.div`
+  padding-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  border-bottom: 4px solid ${(props) => props.theme.primaryMain};
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const Total = styled.div`
+  font: ${(props) => props.theme.captionC1};
+`;
+
+const OrderButton = styled.button`
+  font: ${(props) => props.theme.captionC1};
+  border: none;
+  background-color: transparent;
+`;
+
+const FiltersBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  gap: 8px;
+`;
+
+const FilterButton = styled.div<{ selected: boolean }>`
+  padding: 4px 10px;
+  font: ${(props) => props.theme.captionC1};
+  border: ${(props) =>
+    props.selected ? `2px solid ${props.theme.primary900}` : ''};
+  border-radius: 8px;
+  background-color: ${(props) => props.theme.primaryMain};
+`;
+
+const BottomContent = styled.div`
+  padding: 20px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  overflow-y: auto;
+`;
+
+const EmptyInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  line-height: 100%;
+  font: ${(props) => props.theme.captionC1};
+  color: ${(props) => props.theme.primaryMain};
+`;
+
+export default MyFilteredGoals;

--- a/src/components/goal/StateGoalCard.tsx
+++ b/src/components/goal/StateGoalCard.tsx
@@ -24,7 +24,8 @@ const StateGoalCard = ({ goal }: { goal: IGoal }) => {
 
   useEffect(() => {
     setGoalState();
-  }, []);
+  }, [goal]);
+
   return (
     <Wrapper onClick={() => navigate(`/goals/${goal.id}`)}>
       <TopContent>

--- a/src/components/user/UserDetailProfile.tsx
+++ b/src/components/user/UserDetailProfile.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useQuery } from 'react-query';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import ProfileImg from '../common/elem/ProfileImg';
@@ -17,11 +16,7 @@ interface UserDetailProfileProps {
   workingGoalsCnt: number;
 }
 
-const UserDetailProfile = ({
-  userId,
-  successGoalsCnt,
-  workingGoalsCnt,
-}: UserDetailProfileProps) => {
+const UserDetailProfile = ({ userId, successGoalsCnt, workingGoalsCnt }: UserDetailProfileProps) => {
   const { id } = useRecoilValue(userInfo);
   const [profile, setProfile] = useState<IUserProfile>({
     img: '',
@@ -49,11 +44,7 @@ const UserDetailProfile = ({
     <Wrapper>
       <TopContent>
         <ProfileImg
-          url={
-            profile?.img.length === 0
-              ? require('../../assets/img/default.png')
-              : profile?.img
-          }
+          url={profile?.img.length === 0 ? require('../../assets/img/default.png') : profile?.img}
           size={85}
         />
         <UserGoalsStaticList>

--- a/src/components/user/UserDetailProfile.tsx
+++ b/src/components/user/UserDetailProfile.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import styled from 'styled-components';
+
+import ProfileImg from '../common/elem/ProfileImg';
+
+import { userAPI } from '../../apis/client';
+
+import { IUserProfile } from '../../interfaces/interfaces';
+
+import { userInfo, userProfile } from '../../recoil/atoms';
+
+interface UserDetailProfileProps {
+  userId: number;
+  successGoalsCnt: number;
+  workingGoalsCnt: number;
+}
+
+const UserDetailProfile = ({
+  userId,
+  successGoalsCnt,
+  workingGoalsCnt,
+}: UserDetailProfileProps) => {
+  const { id } = useRecoilValue(userInfo);
+  const [profile, setProfile] = useState<IUserProfile>({
+    img: '',
+    nickname: '',
+    description: '',
+  });
+  const defaultProfile = useRecoilValue(userProfile);
+
+  useEffect(() => {
+    if (userId !== id) {
+      async () => {
+        try {
+          const resp = await userAPI.getUserProfile(userId);
+          setProfile(resp);
+        } catch (e) {
+          alert(e);
+        }
+      };
+    }
+
+    setProfile(defaultProfile);
+  }, [userId, id, defaultProfile]);
+
+  return (
+    <Wrapper>
+      <TopContent>
+        <ProfileImg
+          url={
+            profile?.img.length === 0
+              ? require('../../assets/img/default.png')
+              : profile?.img
+          }
+          size={85}
+        />
+        <UserGoalsStaticList>
+          <UserGoalsStatic>
+            <Info>{successGoalsCnt}</Info>
+            <Label>성공한 목표</Label>
+          </UserGoalsStatic>
+          <UserGoalsStatic>
+            <Info>{workingGoalsCnt}</Info>
+            <Label>진행중 목표</Label>
+          </UserGoalsStatic>
+        </UserGoalsStaticList>
+      </TopContent>
+      <UserInfo>
+        <Nickname>{profile?.nickname}</Nickname>
+        <Description>{profile?.description}</Description>
+      </UserInfo>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  padding: 20px 22px 0 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const TopContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 120px;
+`;
+
+const UserInfo = styled.div`
+  padding: 0 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const Nickname = styled.div`
+  font: ${(props) => props.theme.headingH4};
+`;
+
+const Description = styled.div`
+  font: ${(props) => props.theme.captionC1};
+`;
+
+const UserGoalsStaticList = styled.div`
+  padding: 30px 10px 30px 0;
+  display: flex;
+  flex-direction: row;
+  gap: 40px;
+`;
+
+const UserGoalsStatic = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+`;
+
+const Info = styled.span`
+  font: ${(props) => props.theme.headingH4};
+`;
+
+const Label = styled.span`
+  font: ${(props) => props.theme.captionC2};
+  text-align: center;
+  word-break: keep-all;
+`;
+
+export default UserDetailProfile;

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -45,3 +45,8 @@ export interface IAccountInfo {
   accntNo: string;
   accntPw: string;
 }
+
+export interface IBadge {
+  title: string;
+  description: string;
+}

--- a/src/pages/DetailUser.tsx
+++ b/src/pages/DetailUser.tsx
@@ -1,0 +1,191 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useQuery } from 'react-query';
+import styled from 'styled-components';
+
+import UserDetailProfile from '../components/user/UserDetailProfile';
+import TextButton from '../components/common/elem/TextButton';
+import MyFilteredGoals from '../components/goal/MyFilteredGoals';
+
+import { userGoals, userInfo } from '../recoil/atoms';
+
+import { IBadge, IGoals } from '../interfaces/interfaces';
+
+import { userAPI } from '../apis/client';
+import MyFilteredBadges from '../components/badge/MyFilteredBadges';
+
+interface ITab {
+  title: string;
+  isSelected: boolean;
+}
+
+const DetailUser = () => {
+  const { id } = useParams();
+  const { id: loginUserId } = useRecoilValue(userInfo);
+  if (!id) return <>잘못된 아이디 값입니다</>;
+  const { isLoading: isLoadingGoals, data: userGoalsData } = useQuery<IGoals>(
+    'memberGoals',
+    () => userAPI.getUserGoals(Number(id))
+  );
+  const setUserGoals = useSetRecoilState(userGoals);
+  const filterPrivateUserGoals = (userGoalsData: IGoals) => {
+    const filtered = userGoalsData.goals.filter((goal) => !goal.isPrivate);
+    return filtered;
+  };
+  useEffect(() => {
+    if (!userGoalsData) return;
+    if (Number(id) !== loginUserId) {
+      const filteredGoals = filterPrivateUserGoals(userGoalsData);
+      setUserGoals(filteredGoals);
+    }
+    setUserGoals(userGoalsData.goals);
+  }, [userGoalsData]);
+
+  const goals = useRecoilValue(userGoals);
+
+  const handleUserEdit = () => {
+    console.log('edit user');
+  };
+
+  const [tabs, setTabs] = useState<Array<ITab>>([
+    { title: '목표', isSelected: true },
+    { title: '뱃지', isSelected: false },
+  ]);
+  const handleTabClick = (selectedTab: string) => {
+    setTabs((prev) => {
+      const tabList = [...prev];
+      tabList.map((v) => {
+        if (v.title === selectedTab) {
+          v.isSelected = true;
+          return;
+        }
+        v.isSelected = false;
+      });
+
+      return tabList;
+    });
+  };
+
+  const [successGoalsCnt, setSuccessGoalsCnt] = useState<number>(0);
+  const [workingGoalsCnt, setWorkingGoalsCnt] = useState<number>(0);
+  useEffect(() => {
+    const successGoals = goals.filter(
+      (goal) =>
+        new Date(goal.endDate).getTime() < new Date().getTime() &&
+        goal.attainment === 100
+    );
+    setSuccessGoalsCnt(successGoals.length);
+
+    const workingGoals = goals.filter(
+      (goal) => new Date(goal.startDate).getTime() < new Date().getTime()
+    );
+    setWorkingGoalsCnt(workingGoals.length);
+  }, [goals]);
+
+  const topContentRef = useRef<HTMLDivElement>(null);
+  const [topContentHeight, setTopContentHeight] = useState<number>(0);
+  useEffect(() => {
+    if (!topContentRef.current) return;
+    setTopContentHeight(topContentRef.current.clientHeight);
+  }, [topContentRef]);
+
+  const tabRef = useRef<HTMLDivElement>(null);
+  const [tabHeight, setTabHeight] = useState<number>(0);
+  useEffect(() => {
+    if (!tabRef.current) return;
+    setTabHeight(tabRef.current.clientHeight);
+  }, [tabRef]);
+  return (
+    <Wrapper>
+      <TopContent ref={topContentRef}>
+        <UserDetailProfile
+          userId={Number(id)}
+          successGoalsCnt={successGoalsCnt}
+          workingGoalsCnt={workingGoalsCnt}
+        />
+        <BtnWrapper>
+          <TextButton text='프로필 수정' onClickHandler={handleUserEdit} />
+        </BtnWrapper>
+      </TopContent>
+      <UserContentBox topContentHeight={topContentHeight}>
+        <TabList ref={tabRef}>
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.title}
+              selected={tab.isSelected}
+              onClick={() => handleTabClick(tab.title)}>
+              {tab.title}
+            </Tab>
+          ))}
+        </TabList>
+        <ContentBox tabHeight={tabHeight}>
+          {isLoadingGoals ? (
+            <>로딩중 입니다.</>
+          ) : (
+            tabs.map((tab) => {
+              if (tab.isSelected) {
+                switch (tab.title) {
+                  case '목표':
+                    return (
+                      <MyFilteredGoals
+                        key={tab.title}
+                        isOwner={Number(id) === loginUserId}
+                        goals={goals}
+                      />
+                    );
+                  case '뱃지':
+                    return <MyFilteredBadges key={tab.title} />;
+                }
+              }
+            })
+          )}
+        </ContentBox>
+      </UserContentBox>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  // TODO: set page wrapper height 100%
+  height: calc(100vh - 138px);
+`;
+
+const TopContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const BtnWrapper = styled.div`
+  padding: 20px 22px;
+`;
+
+const UserContentBox = styled.div<{ topContentHeight: number }>`
+  height: ${(props) => `calc(100% - ${props.topContentHeight}px)`};
+  background-color: ${(props) => props.theme.primary50};
+`;
+
+const TabList = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const Tab = styled.div<{ selected: boolean }>`
+  padding: 8px 0;
+  width: 50%;
+  font: ${(props) => props.theme.paragraphsP1M};
+  text-align: center;
+  border-bottom: ${(props) =>
+    props.selected ? `1px solid ${props.theme.primaryMain}` : ''};
+`;
+
+const ContentBox = styled.div<{ tabHeight: number }>`
+  padding: 25px 22px;
+  height: ${(props) => `calc(100% - ${props.tabHeight + 50}px)`};
+`;
+
+const UserBadges = styled.div``;
+
+export default DetailUser;

--- a/src/pages/DetailUser.tsx
+++ b/src/pages/DetailUser.tsx
@@ -7,13 +7,13 @@ import styled from 'styled-components';
 import UserDetailProfile from '../components/user/UserDetailProfile';
 import TextButton from '../components/common/elem/TextButton';
 import MyFilteredGoals from '../components/goal/MyFilteredGoals';
+import MyFilteredBadges from '../components/badge/MyFilteredBadges';
 
 import { userGoals, userInfo } from '../recoil/atoms';
 
-import { IBadge, IGoals } from '../interfaces/interfaces';
+import { IGoals } from '../interfaces/interfaces';
 
 import { userAPI } from '../apis/client';
-import MyFilteredBadges from '../components/badge/MyFilteredBadges';
 
 interface ITab {
   title: string;
@@ -24,9 +24,8 @@ const DetailUser = () => {
   const { id } = useParams();
   const { id: loginUserId } = useRecoilValue(userInfo);
   if (!id) return <>잘못된 아이디 값입니다</>;
-  const { isLoading: isLoadingGoals, data: userGoalsData } = useQuery<IGoals>(
-    'memberGoals',
-    () => userAPI.getUserGoals(Number(id))
+  const { isLoading: isLoadingGoals, data: userGoalsData } = useQuery<IGoals>('memberGoals', () =>
+    userAPI.getUserGoals(Number(id))
   );
   const setUserGoals = useSetRecoilState(userGoals);
   const filterPrivateUserGoals = (userGoalsData: IGoals) => {
@@ -71,15 +70,11 @@ const DetailUser = () => {
   const [workingGoalsCnt, setWorkingGoalsCnt] = useState<number>(0);
   useEffect(() => {
     const successGoals = goals.filter(
-      (goal) =>
-        new Date(goal.endDate).getTime() < new Date().getTime() &&
-        goal.attainment === 100
+      (goal) => new Date(goal.endDate).getTime() < new Date().getTime() && goal.attainment === 100
     );
     setSuccessGoalsCnt(successGoals.length);
 
-    const workingGoals = goals.filter(
-      (goal) => new Date(goal.startDate).getTime() < new Date().getTime()
-    );
+    const workingGoals = goals.filter((goal) => new Date(goal.startDate).getTime() < new Date().getTime());
     setWorkingGoalsCnt(workingGoals.length);
   }, [goals]);
 
@@ -99,11 +94,7 @@ const DetailUser = () => {
   return (
     <Wrapper>
       <TopContent ref={topContentRef}>
-        <UserDetailProfile
-          userId={Number(id)}
-          successGoalsCnt={successGoalsCnt}
-          workingGoalsCnt={workingGoalsCnt}
-        />
+        <UserDetailProfile userId={Number(id)} successGoalsCnt={successGoalsCnt} workingGoalsCnt={workingGoalsCnt} />
         <BtnWrapper>
           <TextButton text='프로필 수정' onClickHandler={handleUserEdit} />
         </BtnWrapper>
@@ -111,10 +102,7 @@ const DetailUser = () => {
       <UserContentBox topContentHeight={topContentHeight}>
         <TabList ref={tabRef}>
           {tabs.map((tab) => (
-            <Tab
-              key={tab.title}
-              selected={tab.isSelected}
-              onClick={() => handleTabClick(tab.title)}>
+            <Tab key={tab.title} selected={tab.isSelected} onClick={() => handleTabClick(tab.title)}>
               {tab.title}
             </Tab>
           ))}
@@ -127,13 +115,7 @@ const DetailUser = () => {
               if (tab.isSelected) {
                 switch (tab.title) {
                   case '목표':
-                    return (
-                      <MyFilteredGoals
-                        key={tab.title}
-                        isOwner={Number(id) === loginUserId}
-                        goals={goals}
-                      />
-                    );
+                    return <MyFilteredGoals key={tab.title} isOwner={Number(id) === loginUserId} goals={goals} />;
                   case '뱃지':
                     return <MyFilteredBadges key={tab.title} />;
                 }
@@ -177,8 +159,7 @@ const Tab = styled.div<{ selected: boolean }>`
   width: 50%;
   font: ${(props) => props.theme.paragraphsP1M};
   text-align: center;
-  border-bottom: ${(props) =>
-    props.selected ? `1px solid ${props.theme.primaryMain}` : ''};
+  border-bottom: ${(props) => (props.selected ? `1px solid ${props.theme.primaryMain}` : '')};
 `;
 
 const ContentBox = styled.div<{ tabHeight: number }>`

--- a/src/shared/Navigation.tsx
+++ b/src/shared/Navigation.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
+
+import { userInfo } from '../recoil/atoms';
 
 const Navigation = () => {
   const navigate = useNavigate();
+  const { id } = useRecoilValue(userInfo);
 
   return (
     <Wrapper>
@@ -25,7 +29,7 @@ const Navigation = () => {
         </SVGIcon>
         <Text>목표 조회</Text>
       </Menu>
-      <Menu>
+      <Menu onClick={() => navigate(`/users/${id}`)}>
         <SVGIcon viewBox='0 0 24 24'>
           <path
             fill='#e4f7ea'

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -6,8 +6,9 @@ import Home from '../pages/Home';
 import PostGoal from '../pages/PostGoal';
 import DetailGoal from '../pages/DetailGoal';
 import GroupGoals from '../pages/GroupGoals';
-import Navigation from './Navigation';
 import SearchGoals from '../pages/SearchGoals';
+import DetailUser from '../pages/DetailUser';
+import Navigation from './Navigation';
 
 const Router = () => {
   return (
@@ -19,6 +20,7 @@ const Router = () => {
         <Route path='/goals/:id' element={<DetailGoal />} />
         <Route path='/goals/lookup' element={<GroupGoals />} />
         <Route path='/goals/lookup/search' element={<SearchGoals />} />
+        <Route path='/users/:id' element={<DetailUser />} />
       </Routes>
       <Navigation />
     </BrowserRouter>


### PR DESCRIPTION
# 사용자 상세 프로필 페이지 구현 (#41)
## 구현 상세
* `src/apis/client.ts` :  사용자 뱃지 목록을 조회해오는 `getUserBadges` client API 구현
* `src/components/` 
  * `badge/MyFilteredBadges.tsx`: 사용자의 획득한 뱃지 목록을 보여주는 컴포넌트 구현
  * `common/elem/BadgeBox.tsx` : 뱃지 하나를 표현하는 공통 컴포넌트 구현
  * `goal/MyFilteredGoals.tsx`: 사용자의 목표 목록을 보여주는 컴포넌트 
  * `user/UserDetailProfile.tsx`: 사용자의 상세 프로필을 보여주는 컴포넌트 구현
* `src/pages/DetailUser.tsx`: 사용자 상세 페이지 구현

## 변경 사항
* `src/interfaces/interfaces.ts`: 뱃지 타입 인터페이스를 추가 
* `src/shared/Navigation.tsx`: 네비게이션 마이페이지 클릭시 로그인한 사용자의 `userId`로 사용자 상세 페이지 이동
* `src/shared/Router.tsx`: 사용자 상세 페이지 라우터 경로 추가
* `src/components/goal/StateGoalCard.tsx`: `goal` props가 업데이트 되면 목표 카드 리랜더링이 일어나도록 useEffect 의존성 배열에 `goal` 추가