### PR TITLE
FEAT: add layout component

### DIFF
--- a/src/shared/Header.tsx
+++ b/src/shared/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Ref, forwardRef } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import styled from 'styled-components';
 
@@ -6,7 +6,11 @@ import Logo from '../components/common/elem/Logo';
 import Icon from '../components/common/elem/Icon';
 import SearchBar from '../components/header/SearchBar';
 
-const Header = () => {
+interface HeaderProps {
+  props: string;
+}
+
+const Header = (props: HeaderProps, ref: Ref<HTMLDivElement>) => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const [showSearchBar, setShowSearchBar] = useState<boolean>(false);
@@ -20,7 +24,7 @@ const Header = () => {
   }, [pathname]);
 
   return (
-    <HeaderLayout showBgColor={!showSearchBar}>
+    <HeaderLayout ref={ref} showBgColor={!showSearchBar}>
       {pathname === '/' ? <Logo size='small' /> : <></>}
       <Button show={showSearchBar} onClick={handleSearch}>
         <Icon
@@ -92,4 +96,4 @@ const PageName = styled.div<{ show: boolean }>`
   font: ${(props) => props.theme.paragraphP2};
 `;
 
-export default Header;
+export default forwardRef(Header);

--- a/src/shared/Layout.tsx
+++ b/src/shared/Layout.tsx
@@ -1,0 +1,31 @@
+import React, { FunctionComponent, PropsWithChildren, useRef, useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+import Header from './Header';
+import Navigation from './Navigation';
+
+const Layout: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const headerRef = useRef<HTMLDivElement>(null);
+  const navRef = useRef<HTMLDivElement>(null);
+
+  const [headerNavHeight, setHeaderNavHeight] = useState<number>(0);
+  useEffect(() => {
+    if (!headerRef.current || !navRef.current) return;
+    setHeaderNavHeight(headerRef.current.clientHeight + navRef.current.clientHeight);
+  }, [headerRef.current, navRef.current]);
+  return (
+    <>
+      <Header props='' ref={headerRef} />
+      <Body height={`${headerNavHeight}px`}>{children}</Body>
+      <Navigation props='' ref={navRef} />
+    </>
+  );
+};
+
+const Body = styled.div<{ height: string }>`
+  width: 100%;
+  height: ${(props) => `calc(100vh - ${props.height})`};
+  background-color: ${(props) => props.theme.gray100};
+`;
+
+export default Layout;

--- a/src/shared/Navigation.tsx
+++ b/src/shared/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, forwardRef, Ref } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
@@ -13,7 +13,11 @@ enum Menu {
   my,
 }
 
-const Navigation = () => {
+interface NavProps {
+  props: string;
+}
+
+const Navigation = (props: NavProps, ref: Ref<HTMLDivElement>) => {
   const navigate = useNavigate();
   const { id } = useRecoilValue(userInfo);
 
@@ -33,7 +37,7 @@ const Navigation = () => {
   };
 
   return (
-    <Wrapper>
+    <Wrapper ref={ref}>
       <Button onClick={() => handleMenuSelect(Menu.home)}>
         <Icon
           size={24}
@@ -91,4 +95,4 @@ const Text = styled.div`
   font: ${(props) => props.theme.paragraphP3M};
 `;
 
-export default Navigation;
+export default forwardRef(Navigation);

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -1,28 +1,27 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
-import Header from './Header';
 import Home from '../pages/Home';
 import PostGoal from '../pages/PostGoal';
 import DetailGoal from '../pages/DetailGoal';
 import GroupGoals from '../pages/GroupGoals';
 import SearchGoals from '../pages/SearchGoals';
 import DetailUser from '../pages/DetailUser';
-import Navigation from './Navigation';
+import Layout from './Layout';
 
 const Router = () => {
   return (
     <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path='/' element={<Home />} />
-        <Route path='/goals/post' element={<PostGoal />} />
-        <Route path='/goals/:id' element={<DetailGoal />} />
-        <Route path='/goals/lookup' element={<GroupGoals />} />
-        <Route path='/goals/lookup/search' element={<SearchGoals />} />
-        <Route path='/users/:id' element={<DetailUser />} />
-      </Routes>
-      <Navigation />
+      <Layout>
+        <Routes>
+          <Route path='/' element={<Home />} />
+          <Route path='/goals/post' element={<PostGoal />} />
+          <Route path='/goals/:id' element={<DetailGoal />} />
+          <Route path='/goals/lookup' element={<GroupGoals />} />
+          <Route path='/goals/lookup/search' element={<SearchGoals />} />
+          <Route path='/users/:id' element={<DetailUser />} />
+        </Routes>
+      </Layout>
     </BrowserRouter>
   );
 };


### PR DESCRIPTION
# Layout 컴포넌트 구현 (#57)
## 구현 상세
* `src/shared/Layout.tsx`: Header, Navigation 컴포넌트의 높이를 구해 viewHeight에서 두 요소의 높이를 뺀 값을 Router로 이동하는 모든 페이지를 감싸는 Body Height 값으로 사용

## 변경 사항
* `src/shared/Header.tsx`: `useRef`를 Layout으로부터 받아 가장 부모 요소인 Wrapper를 ref할 수 있도록 수정
* `src/shared/Router.tsx`: `useRef`를 Layout으로부터 받아 가장 부모 요소인 Wrapper를 ref할 수 있도록 수정
* `src/shared/Router.tsx`: Layout 컴포넌트가 Router 경로로 이동 가능한 페이지를 모두 감쌀 수 있도록 수정