### PR TITLE
FIX: fix components to use icon atomic component correctly

### DIFF
--- a/src/components/common/elem/ModalBox.tsx
+++ b/src/components/common/elem/ModalBox.tsx
@@ -9,21 +9,16 @@ interface ModalBoxProps {
   children: React.ReactNode;
 }
 
-const ModalBox: FunctionComponent<ModalBoxProps> = ({
-  title,
-  closeHandler,
-  children,
-}) => {
+const ModalBox: FunctionComponent<ModalBoxProps> = ({ title, closeHandler, children }) => {
   return (
     <Modal>
       <ContentWrapper>
         <Button onClick={closeHandler}>
-          <Icon>
-            <path
-              fill='#5fcf8a'
-              d='M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z'
-            />
-          </Icon>
+          <Icon
+            size={24}
+            color={'primary400'}
+            path='M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z'
+          />
         </Button>
         <Title>{title}</Title>
         <Content>{children}</Content>

--- a/src/components/common/tag/HashTag.tsx
+++ b/src/components/common/tag/HashTag.tsx
@@ -13,10 +13,7 @@ export interface IHashTag {
   bgColor: string;
 }
 
-const HashTag = React.memo(function HashTag({
-  tag: { content, bgColor },
-  removeHandler,
-}: HashTagProps) {
+const HashTag = React.memo(function HashTag({ tag: { content, bgColor }, removeHandler }: HashTagProps) {
   return (
     <Tag bgColor={bgColor}>
       {`#${content}`}
@@ -24,12 +21,11 @@ const HashTag = React.memo(function HashTag({
         <></>
       ) : (
         <DeleteButton onClick={() => removeHandler({ content, bgColor })}>
-          <Icon>
-            <path
-              fill='#e4f7ea'
-              d='M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z'
-            />
-          </Icon>
+          <Icon
+            size={12}
+            color={'gray400'}
+            path='M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z'
+          />
         </DeleteButton>
       )}
     </Tag>


### PR DESCRIPTION
# Icon 컴포넌트 사용하는 컴포넌트들 수정
## 변경 사항
* `src/components/common/elem/ModalBox.tsx` : Icon 컴포넌트에 필요한 props를 넘기도록 수정
* `src/components/common/tag/HashTag.tsx`: Icon 컴포넌트에 필요한 props를 넘기도록 수정