### PR TITLE
FIX: fix layout component to recalculate body element height on URL path change

### DIFF
--- a/src/shared/Layout.tsx
+++ b/src/shared/Layout.tsx
@@ -1,18 +1,21 @@
 import React, { FunctionComponent, PropsWithChildren, useRef, useState, useEffect } from 'react';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import Header from './Header';
 import Navigation from './Navigation';
 
 const Layout: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const { pathname } = useLocation();
   const headerRef = useRef<HTMLDivElement>(null);
   const navRef = useRef<HTMLDivElement>(null);
 
   const [headerNavHeight, setHeaderNavHeight] = useState<number>(0);
   useEffect(() => {
     if (!headerRef.current || !navRef.current) return;
+    if (pathname === '/goals/post') return setHeaderNavHeight(headerRef.current.clientHeight);
     setHeaderNavHeight(headerRef.current.clientHeight + navRef.current.clientHeight);
-  }, [headerRef.current, navRef.current]);
+  }, [headerRef.current?.clientHeight, navRef.current?.clientHeight, pathname]);
   return (
     <>
       <Header props='' ref={headerRef} />


### PR DESCRIPTION
# layout 컴포넌트 수정
## 변경 사항
* `src/shared/Layout.tsx` : 현재 페이지 경로에 따라 네비게이션 바를 사용하지 않는 페이지인 경우 body element의 height 값을 재계산 하도록 수정