### PR TITLE
FIX: fix post goal page to get banks info on goal info input section

### DIFF
--- a/src/pages/PostGoal.tsx
+++ b/src/pages/PostGoal.tsx
@@ -1,11 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useSetRecoilState } from 'recoil';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import GoalInfoInput from '../components/goal/post/GoalInfoInput';
 
+import { goalApi } from '../apis/client';
+
+import { IBank } from '../interfaces/interfaces';
+
+import { banksInfo } from '../recoil/accntAtoms';
+
 const PostGoal = () => {
   const { type } = useParams();
+  const { data: banks } = useQuery<Array<IBank>>('getBanks', () => goalApi.getBanks());
+  const setBanksInfo = useSetRecoilState(banksInfo);
+  useEffect(() => {
+    if (!banks) return;
+    setBanksInfo(banks.slice(2, -1));
+  }, [banks]);
+
   return (
     <Wrapper>
       <GoalInfoInput isGroup={type === 'group'} />

--- a/src/pages/SelectType.tsx
+++ b/src/pages/SelectType.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import TypeSelect from '../components/goal/post/TypeSelect';


### PR DESCRIPTION
# 목표 추가 페이지 은행 목록 조회 요청 로직 수정
## 변경 사항
* 목표 추가 페이지의 목표 정보 입력창 부분에서 은행 목록 조회 요청 및 은행 목록 정보 atom에 저장