### PR TITLE
FIX: fix login logic and client APIs to use correct header and types

### DIFF
--- a/src/pages/NaverLogin.tsx
+++ b/src/pages/NaverLogin.tsx
@@ -1,17 +1,46 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
+import jwtDecoder from 'jwt-decode';
 
 import { userAPI } from '../apis/client';
 
+import { userInfo } from '../recoil/userAtoms';
+
+import { MyToken } from '../interfaces/interfaces';
+
 const NaverLogin = () => {
-  const navigation = useNavigate();
-
+  const navigate = useNavigate();
   const code = new URL(window.location.href).searchParams.get('code');
-
+  const setUserInfo = useSetRecoilState(userInfo);
+  const signup = async () => {
+    try {
+      if (!code) return alert('잘못된 코드를 받았습니다.');
+      const data = await userAPI.getNaverSignup(code);
+      localStorage.setItem('accessToken', data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
+      setUserInfo({
+        id: jwtDecoder<MyToken>(data.accessToken).userId,
+        isLogin: true,
+        isAccessToken: true,
+        isRefreshToken: true,
+      });
+      navigate('/home');
+    } catch (e) {
+      console.log('naver signup error:', e);
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      setUserInfo({
+        id: 0,
+        isLogin: false,
+        isAccessToken: false,
+        isRefreshToken: false,
+      });
+    }
+  };
   useEffect(() => {
-    userAPI.getNaverSignup(code);
-    navigation('/pinnumber');
+    signup();
   }, []);
 
   return <Wrapper>네이버로 로그인 중입니다</Wrapper>;


### PR DESCRIPTION
# 로그인 로직 수정
## 변경 사항
* `src/pages/NaverLogin.tsx`: 네이버 로그인 성공 직후 atom 업데이트 및 localStorage token 저장
* `src/pages/PinNumberInputPage.tsx`: accessToken이 없는 경우 pin number 6자리 입력시 access token 요청, 성공 직후 atom 업데이트 및 localStorage token 저장
# 클라이언트 API 수정
* tokenClient header 잘못된 필드명 수정
* accessToken 요청 시, refreshToken을 헤더 값에 넣어 보내는 refreshClinet 추가
* type이 잘못 지정되어 있는 부분 수정