### PR TITLE
FIX: fix user detail state goal card date type error

### DIFF
--- a/src/components/goal/StateGoalCard.tsx
+++ b/src/components/goal/StateGoalCard.tsx
@@ -42,7 +42,7 @@ const StateGoalCard = ({ goal }: { goal: IGoal }) => {
           </Content>
         </TopLeftContent>
         <TopRightContent>
-          <DdayTag dDay={dDayCalculator(goal.endDate)} />
+          <DdayTag dDay={dDayCalculator(new Date(goal.endDate))} />
         </TopRightContent>
       </TopContent>
       <BottomContent>


### PR DESCRIPTION
# 사용자 상세 페이지의 날짜 타입 수정
## 변경 사항
* 사용자 상세 페이지의 목표 카드에서 `dDayCalculator`는 `Date`타입의 인자를 받기 때문에 `string` 타입의 날짜를 `Date` 타입으로 변환하도록 수정