### PR TITLE
FIX: fix goal data create page to validate data on err msg update

### DIFF
--- a/src/components/goal/post/GoalInfoInput.tsx
+++ b/src/components/goal/post/GoalInfoInput.tsx
@@ -139,7 +139,7 @@ function GoalInfoInput({ isGroup }: GoalInfoInputProps) {
 
   useEffect(() => {
     validate();
-  }, [emoji, title, description, amount, headCount]);
+  }, [emoji, title, description, amount, headCount, titleErr, descriptionErr, amountErr, headCountErr]);
 
   const setPostGoal = useSetRecoilState(postGoal);
   const setPostGoalType = useSetRecoilState(postGoalType);


### PR DESCRIPTION
# 그룹 목표 인원 수 입력 버그 수정
## 변경 사항
* `src/components/goal/post/GoalInfoInput.tsx`: validate 함수를 input custom hook의 err 값 변경 시에도 실행하도록 수정