### PR TITLE
REFACTOR: modify home page component to handle get data logic in hooks

### DIFF
--- a/src/hooks/useBanksData.tsx
+++ b/src/hooks/useBanksData.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { useQuery } from 'react-query';
+
+import { IBank } from '../interfaces/interfaces';
+
+import { goalApi } from '../apis/client';
+
+import { banksInfo } from '../recoil/accntAtoms';
+
+function useBanksData() {
+  const { data: banksData } = useQuery<Array<IBank>>('getBanks', () => goalApi.getBanks());
+  const setBanksInfo = useSetRecoilState(banksInfo);
+  useEffect(() => {
+    if (!banksData) return;
+    setBanksInfo(banksData.slice(2, -1));
+  }, [banksData]);
+
+  return;
+}
+
+export default useBanksData;

--- a/src/hooks/useUserData.tsx
+++ b/src/hooks/useUserData.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useSetRecoilState } from 'recoil';
+
+import { IUserProfile, IGoals } from '../interfaces/interfaces';
+
+import { userAPI } from '../apis/client';
+
+import { userGoals, userProfile } from '../recoil/userAtoms';
+
+interface useUserDataProps {
+  loginUserId: number;
+  getUserId: number;
+}
+
+const useUserData = ({ loginUserId, getUserId }: useUserDataProps) => {
+  const isLoginUser = loginUserId === getUserId;
+  const { data: profileData } = useQuery<IUserProfile>('userProfile', () => userAPI.getUserProfile(getUserId));
+  const setUserProfile = useSetRecoilState(userProfile);
+  useEffect(() => {
+    if (!profileData || !isLoginUser) return;
+    setUserProfile(profileData);
+  }, [profileData]);
+
+  const { isLoading, data: goalsData, isError } = useQuery<IGoals>('userGoals', () => userAPI.getUserGoals(getUserId));
+  const setUserGoals = useSetRecoilState(userGoals);
+  useEffect(() => {
+    if (!goalsData || !isLoginUser) return;
+    setUserGoals(goalsData.result);
+  }, [goalsData]);
+
+  return { isLoading, isError, profileData, goalsData };
+};
+
+export default useUserData;

--- a/src/pages/CreateGoalData.tsx
+++ b/src/pages/CreateGoalData.tsx
@@ -1,25 +1,11 @@
-import React, { useEffect } from 'react';
-import { useQuery } from 'react-query';
-import { useSetRecoilState } from 'recoil';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import GoalInfoInput from '../components/goal/post/GoalInfoInput';
 
-import { goalApi } from '../apis/client';
-
-import { IBank } from '../interfaces/interfaces';
-
-import { banksInfo } from '../recoil/accntAtoms';
-
 const CreateGoalData = () => {
   const { type } = useParams();
-  const { data: banks } = useQuery<Array<IBank>>('getBanks', () => goalApi.getBanks());
-  const setBanksInfo = useSetRecoilState(banksInfo);
-  useEffect(() => {
-    if (!banks) return;
-    setBanksInfo(banks.slice(2, -1));
-  }, [banks]);
 
   return (
     <Wrapper>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,7 +36,13 @@ const Home = () => {
             <ErrorMsg />
           </Alert>
         ) : (
-          goals.map((goal) => <MyGoalCard key={goal.goalId} goal={goal} />)
+          goals
+            .filter(
+              (goal) =>
+                new Date(goal.startDate).getTime() < new Date().getTime() &&
+                new Date(goal.endDate).getTime() > new Date().getTime()
+            )
+            .map((goal) => <MyGoalCard key={goal.goalId} goal={goal} />)
         )}
         <AddGoalBtn onClick={() => navigate('/goals/post/type')}>
           <IconWrapper>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { useQuery } from 'react-query';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import UserProfile from '../components/user/UserProfile';
@@ -11,36 +10,24 @@ import Alert from '../components/common/alert/Alert';
 import LoadingMsg from '../components/common/elem/LoadingMsg';
 import ErrorMsg from '../components/common/elem/ErrorMsg';
 
-import { userGoals, userId } from '../recoil/userAtoms';
+import { userId, userGoals, userProfile } from '../recoil/userAtoms';
 
-import { IGoals, IUserProfile } from '../interfaces/interfaces';
-
-import { userAPI } from '../apis/client';
+import useBanksData from '../hooks/useBanksData';
+import useUserData from '../hooks/useUserData';
 
 const Home = () => {
+  useBanksData();
   const { id } = useRecoilValue(userId);
-  const { data: profile } = useQuery<IUserProfile>('userProfile', () => userAPI.getUserProfile(id));
-
-  const {
-    isLoading: isLoadingGoals,
-    data: userGoalsData,
-    isError,
-  } = useQuery<IGoals>('userGoals', () => userAPI.getUserGoals(id));
-  const setUserGoals = useSetRecoilState(userGoals);
+  const { isLoading, isError } = useUserData({ loginUserId: id, getUserId: id });
+  const profile = useRecoilValue(userProfile);
   const goals = useRecoilValue(userGoals);
-
-  useEffect(() => {
-    if (!userGoalsData) return;
-    setUserGoals(userGoalsData.result);
-  }, [userGoalsData]);
-
   const navigate = useNavigate();
 
   return (
     <Wrapper>
-      {!profile ? <></> : <UserProfile profile={profile} />}
+      <UserProfile profile={profile} />
       <ContentWrapper>
-        {isLoadingGoals ? (
+        {isLoading ? (
           <Alert height={150} showBgColor={true}>
             <LoadingMsg />
           </Alert>
@@ -49,7 +36,7 @@ const Home = () => {
             <ErrorMsg />
           </Alert>
         ) : (
-          goals?.map((goal) => <MyGoalCard key={goal.goalId} goal={goal} />)
+          goals.map((goal) => <MyGoalCard key={goal.goalId} goal={goal} />)
         )}
         <AddGoalBtn onClick={() => navigate('/goals/post/type')}>
           <IconWrapper>


### PR DESCRIPTION
# home 페이지 관심사 분리되도록 수정
## 문제 상황
* 페이지 UI를 구현하는 로직과 데이터를 불러오는 로직이 한 곳에서 관리됨
* 메인 페이지에서 목표 상세로 이동 시, 연결된 계좌 정보에 은행 이름이 표시되지 않음
* 메인 페이지에서 목표 진행 기간이 지난 목표 목록이 보임

## 변경 사항
* `src/hooks/useBanksData.tsx`: 서비스에서 지원하는 은행 목록 데이터 불러와서 atom에 저장하는 로직을 관리하는 훅 구현
* `src/hooks/useUserData.tsx`: 사용자 관련 정보(프로필, 사용자 참여 목표)를 불러와서 atom에 저장하는 로직을 관리하는 훅 구현
* `src/pages/CreateGoalData.tsx`: 은행 목록 불러오는 로직 삭제
* `src/pages/Home.tsx`: 
  * 은행 목록 불러오는 훅 사용
  * 사용자 관련 정보 불러오는 훅 사용
  * 사용자 목표 정보를 현재 진행 중인 목표만 보이도록 필터링