### PR TITLE
FIX: modify account related pages path name to share logic

### DIFF
--- a/src/components/account/AccountSelectSection.tsx
+++ b/src/components/account/AccountSelectSection.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import AccountInfoCard from './AccountInfoCard';
-
-import { postGoal } from '../../recoil/goalsAtoms';
 
 import { IAccount } from '../../interfaces/interfaces';
 
 interface AccountSelectProps {
   accounts: Array<IAccount>;
+  accountSelectHandler: (accountId: number) => void;
 }
 
-const AccountSelect = ({ accounts }: AccountSelectProps) => {
-  const savedPostGoal = useRecoilValue(postGoal);
-  const setPostGoal = useSetRecoilState(postGoal);
+const AccountSelect = ({ accounts, accountSelectHandler }: AccountSelectProps) => {
   const handleSelect = (accountId: number) => {
-    setPostGoal({ ...savedPostGoal, accountId });
+    accountSelectHandler(accountId);
   };
 
   return (
@@ -24,7 +20,11 @@ const AccountSelect = ({ accounts }: AccountSelectProps) => {
       <ContentWrapper>
         <SubTitle>연결된 계좌</SubTitle>
         {accounts.map((account) => (
-          <AccountInfoCard key={account.accountId} accntInfo={account} selectHandler={handleSelect} />
+          <AccountInfoCard
+            key={account.accountId}
+            accntInfo={account}
+            selectHandler={() => handleSelect(account.accountId)}
+          />
         ))}
       </ContentWrapper>
     </Wrapper>

--- a/src/components/goal/post/GoalInfoInput.tsx
+++ b/src/components/goal/post/GoalInfoInput.tsx
@@ -187,7 +187,8 @@ function GoalInfoInput({ isGroup }: GoalInfoInputProps) {
         isManual: isManual,
         accountId: 0,
       });
-      navigate('/goals/post/account/choose');
+
+      navigate('/accounts/choose');
     }
   };
 

--- a/src/hooks/useAccountsData.tsx
+++ b/src/hooks/useAccountsData.tsx
@@ -1,0 +1,21 @@
+import { useQuery } from 'react-query';
+import { useRecoilValue } from 'recoil';
+
+import { userId } from '../recoil/userAtoms';
+
+import { accountApi } from '../apis/client';
+
+const useAccountsData = () => {
+  const { id: loginUserId } = useRecoilValue(userId);
+  const {
+    isLoading,
+    data: accounts,
+    isError,
+  } = useQuery('getAccounts', () => accountApi.getAccounts(loginUserId), {
+    select: (data) => data.filter((v) => v.bankId !== 2),
+  });
+
+  return { isLoading, accounts, isError };
+};
+
+export default useAccountsData;

--- a/src/hooks/useNavigateState.tsx
+++ b/src/hooks/useNavigateState.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export enum Menu {
+  home,
+  lookup,
+  my,
+  none,
+}
+
+const pathMenuConverter = (path: string) => {
+  if (path.includes('/goals/lookup')) return Menu.lookup;
+  if (path.includes('/users/')) return Menu.my;
+  if (path === '/home') return Menu.home;
+
+  return Menu.none;
+};
+
+interface useNavigateStateProps {
+  pathname: string;
+  userId: number;
+}
+
+const useNavigateState = ({ pathname, userId }: useNavigateStateProps) => {
+  const navigate = useNavigate();
+  const [show, setShow] = useState<boolean>(true);
+  const [selectedMenu, setSelectedMenu] = useState<Menu>(Menu.home);
+  const handleMenuSelect = (menu: Menu) => {
+    switch (menu) {
+      case Menu.home:
+        setSelectedMenu(Menu.home);
+        return navigate('/home');
+      case Menu.lookup:
+        setSelectedMenu(Menu.lookup);
+        return navigate('/goals/lookup');
+      case Menu.my:
+        setSelectedMenu(Menu.my);
+        return navigate(`/users/${userId}`);
+    }
+  };
+
+  useEffect(() => {
+    if (pathname.includes('/goals/') && !pathname.includes('lookup')) return setShow(false);
+    if (pathname.includes('/accounts')) return setShow(false);
+
+    setShow(true);
+    handleMenuSelect(pathMenuConverter(pathname));
+  }, [pathname]);
+
+  return { selectedMenu, show, handleMenuSelect };
+};
+
+export default useNavigateState;

--- a/src/shared/AuthLayout.tsx
+++ b/src/shared/AuthLayout.tsx
@@ -26,7 +26,7 @@ const AuthLayout = () => {
 
   useEffect(() => {
     if (!headerRef.current) return;
-    if (pathname.includes('/goals/') && !pathname.includes('lookup')) {
+    if ((pathname.includes('/goals/') && !pathname.includes('lookup')) || pathname.includes('/accounts')) {
       return setHeaderNavHeight(headerRef.current.clientHeight);
     }
     setHeaderNavHeight(headerRef.current.clientHeight + 88);

--- a/src/shared/Navigation.tsx
+++ b/src/shared/Navigation.tsx
@@ -1,54 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import React from 'react';
+import { useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
+import { Menu } from '../hooks/useNavigateState';
+
 import Icon from '../components/common/elem/Icon';
+
+import useNavigateState from '../hooks/useNavigateState';
 
 import { userId } from '../recoil/userAtoms';
 
-enum Menu {
-  home,
-  lookup,
-  my,
-  none,
-}
-
-const pathMenuConverter = (path: string) => {
-  if (path.includes('/goals/lookup')) return Menu.lookup;
-  if (path.includes('/users/')) return Menu.my;
-  if (path === '/home') return Menu.home;
-
-  return Menu.none;
-};
-
 const Navigation = () => {
-  const navigate = useNavigate();
   const { id } = useRecoilValue(userId);
-
-  const [selectedMenu, setSelectedMenu] = useState<Menu>(Menu.home);
-  const handleMenuSelect = (menu: Menu) => {
-    switch (menu) {
-      case Menu.home:
-        setSelectedMenu(Menu.home);
-        return navigate('/home');
-      case Menu.lookup:
-        setSelectedMenu(Menu.lookup);
-        return navigate('/goals/lookup');
-      case Menu.my:
-        setSelectedMenu(Menu.my);
-        return navigate(`/users/${id}`);
-    }
-  };
-
-  const [show, setShow] = useState<boolean>(true);
   const { pathname } = useLocation();
-  useEffect(() => {
-    if (pathname.includes('/goals/') && !pathname.includes('lookup')) return setShow(false);
-    setShow(true);
+  const { selectedMenu, show, handleMenuSelect } = useNavigateState({ pathname, userId: id });
 
-    handleMenuSelect(pathMenuConverter(pathname));
-  }, [pathname]);
   return (
     <Wrapper show={show}>
       <Button show={show} onClick={() => handleMenuSelect(Menu.home)}>

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -39,8 +39,8 @@ const Router = () => {
           <Route path='/agreement' element={<AgreementOfCollectionPersonalInfo />} />
           <Route path='/goals/post/type' element={<SelectGoalType />} />
           <Route path='/goals/post/data/:type' element={<CreateGoalData />} />
-          <Route path='/goals/post/account/choose' element={<SelectAccnt />} />
-          <Route path='/goals/post/account/post' element={<CreateAccnt />} />
+          <Route path='/accounts/choose' element={<SelectAccnt />} />
+          <Route path='/accounts/post' element={<CreateAccnt />} />
           <Route path='/goals/:id' element={<DetailGoal />} />
           <Route path='/goals/lookup' element={<LookupGoals />} />
           <Route path='/goals/lookup/search' element={<SearchGoals />} />


### PR DESCRIPTION
# 계좌 관련 페이지 경로 수정 및 리팩토링
## 변경 사항
* `src/components/goal/post/GoalInfoInput.tsx`: 변경된 계좌 선택 페이지 pathname을 사용하도록 수정
* `src/hooks/useAccountsData.tsx`: 사용자 계좌 목록 정보를 불러오고 직접 입력 계좌를 필터링 해주는 로직을 관리하는 훅 구현
* `src/hooks/useNavigateState.tsx`: pathname을 통해 현재 네비게이션 바의 상태를 관리하는 훅 구현
* `src/pages/SelectAccnt.tsx`: 
  * `useAccountsData` 훅을 사용하도록 수정
  * `AccountSelect` 컴포넌트가 selectHandler를 props로 받도록 수정한 사항에 맞춰 변경
* `src/shared/AuthLayout.tsx`: 변경된 계좌 관련 페이지 pathname에 따라 레이아웃이 변경될 수 있도록 수정
* `src/shared/Navigation.tsx`: `useNavigateState` 훅을 사용하도록 수정
* `src/shared/Router.tsx`: 계좌 관련 페이지가 목표 추가 로직 이외에도 목표 참여 로직에 사용하기 위해 pathname 수정