### PR TITLE
FIX: fix to handle unauthorized error in hooks

### DIFF
--- a/src/components/account/AccountNoInput.tsx
+++ b/src/components/account/AccountNoInput.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
@@ -67,7 +66,7 @@ const AccountNoInput = ({ oriSeqNoHandler, authReqHandler }: AccountNoInputProps
   });
 
   if (isLoading) return <>Loading...</>;
-  if (isError) return <Navigate to='/' />;
+  if (isError) return <>Error</>;
 
   return (
     <Wrapper>

--- a/src/components/goal/MyFilteredGoals.tsx
+++ b/src/components/goal/MyFilteredGoals.tsx
@@ -41,7 +41,7 @@ const MyFilteredGoals = ({ isLoading, isError, goals }: MyFilteredGoalsProps) =>
   };
 
   if (isLoading) return <>Loading...</>;
-  if (isError) return <Navigate to='/' />;
+  if (isError) return <>Error</>;
 
   const { filterType, orderType, filtered, handleFilterType, handleOrderType } = useGoalsFilter({ goals });
 

--- a/src/components/goal/goalDetail/group/JoinButton.tsx
+++ b/src/components/goal/goalDetail/group/JoinButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import TextButton from '../../../common/elem/TextButton';
@@ -27,7 +26,7 @@ const JoinButton = ({ goalId }: { goalId: number }) => {
   } = useJoinGoalModal({ goalId });
 
   if (isLoading || !accounts) return <>Loading...</>;
-  if (isError) return <Navigate to='/' />;
+  if (isError) return <>Error</>;
 
   return (
     <>

--- a/src/components/goal/modify/AccntToggle.tsx
+++ b/src/components/goal/modify/AccntToggle.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import useAccountsData from '../../../hooks/useAccountsData';
-import { isManualAccntAddable } from '../../../utils/accountInfoChecker';
 
 import ToggleSelectBox from '../../common/elem/ToggleSelectBox';
 import ValidateMsg from '../../common/elem/ValidateMsg';
+
+import { isManualAccntAddable } from '../../../utils/accountInfoChecker';
 
 interface AccntToggleProps {
   initVal: boolean;
@@ -29,10 +30,14 @@ const AccntToggle = ({ initVal, changeHandler }: AccntToggleProps) => {
         description='실제 계좌를 연결하지 않고 계좌 잔액을 직접 입력합니다.'
         initVal={isManual}
         selectHandler={handleSelectisAuto}
-        isDisabled={!isManualAccntAddable(accounts)}
+        // TODO: 토글 disable 수정 페이지에서만 동작하도록
+        // 직접 입력 계좌 addable 함수 디버깅
+        // isLoading, isError 일 때 disable
+        // isDisabled={!isManualAccntAddable(accounts)}
       />
+      {isError ? <ValidateMsg msg='계좌 정보 조회를 실패했습니다.' type='error' /> : <></>}
       {isManual && !isManualAccntAddable(accounts) ? (
-        <ValidateMsg msg='잔액은 최대 10개까지 관리할 수 있습니다.' type='error' />
+        <ValidateMsg msg='직접 입력 목표는 최대 10개까지 관리할 수 있습니다.' type='error' />
       ) : (
         <></>
       )}

--- a/src/components/goal/post/goalInfo/DateSelectSection.tsx
+++ b/src/components/goal/post/goalInfo/DateSelectSection.tsx
@@ -5,7 +5,6 @@ import DateSelectBox from '../../../common/elem/DateSelectBox';
 
 import useDateInput from '../../../../hooks/useDateInput';
 import { dateStringTranslatorWithPoint } from '../../../../utils/dateTranslator';
-import DateInput from '../../input/DateInput';
 
 interface DateSelectSectionProps {
   isGroup: boolean;

--- a/src/components/user/UserDetailProfile.tsx
+++ b/src/components/user/UserDetailProfile.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import ProfileImg from '../common/elem/ProfileImg';
@@ -17,7 +16,7 @@ const UserDetailProfile = ({ id, totalCnt, successCnt, workingCnt }: UserDetailP
   const { isLoading, isError, profile } = useUserProfileData({ getUserId: id });
 
   if (isLoading && !profile) return <>Loading...</>;
-  if (isError || !profile) return <Navigate to='/' />;
+  if (isError || !profile) return <>Error</>;
 
   return (
     <Wrapper>

--- a/src/hooks/useAccntAutoPost.tsx
+++ b/src/hooks/useAccntAutoPost.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { useMutation } from 'react-query';
 
@@ -9,12 +10,19 @@ import { accountApi } from '../apis/client';
 
 const useAccntAutoPost = ({ acctInfo }: { acctInfo: IPostAccount }) => {
   const { id: loginUserId } = useRecoilValue(userId);
+  const navigate = useNavigate();
   const {
     isLoading,
     isError,
     data: accountId,
     mutate,
-  } = useMutation<number, unknown, IPostAutoAccount>('postAccount', accountApi.createAutoAccount);
+  } = useMutation<number, unknown, IPostAutoAccount>('postAccount', accountApi.createAutoAccount, {
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
+    },
+  });
   const handlePostAccount = () => {
     mutate({ userId: loginUserId, acctInfo });
   };

--- a/src/hooks/useAccntManualPost.tsx
+++ b/src/hooks/useAccntManualPost.tsx
@@ -28,6 +28,11 @@ const useAccntManualPost = ({ type, goalId }: useAccntManualPostProps) => {
         setTimeout(() => navigate(`/goals/post/${data}`, { replace: true }), 2000);
       }
     },
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
+    },
   });
 
   return { isLoading, isError, createManualAccnt };

--- a/src/hooks/useBalanceData.tsx
+++ b/src/hooks/useBalanceData.tsx
@@ -1,18 +1,27 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { useRecoilValue } from 'recoil';
+
 import { accountApi } from '../apis/client';
+
 import { userId } from '../recoil/userAtoms';
 
 const useBalanceData = ({ accountId }: { accountId: number }) => {
   const [balance, setBalance] = useState<number>(0);
   const { id: loginUserId } = useRecoilValue(userId);
+  const navigate = useNavigate();
   const { isLoading, isError } = useQuery(
     'accountBalance',
     () => accountApi.getAccountBalance({ userId: loginUserId, accountId }),
     {
       onSuccess: (data) => {
         setBalance(data);
+      },
+      onError: (e) => {
+        if (e === 401) {
+          navigate('/', { replace: true });
+        }
       },
     }
   );

--- a/src/hooks/useBalanceModify.tsx
+++ b/src/hooks/useBalanceModify.tsx
@@ -22,16 +22,21 @@ const useBalanceModify = ({ balanceId, accountId }: { balanceId: number; account
 
   const { id: loginUserId } = useRecoilValue(userId);
   const [balance, setBalance] = useState<number>(0);
-  const {
-    isLoading: isLoadingData,
-    isError: isErrorData,
-    refetch,
-  } = useQuery('accountBalance', () => accountApi.getAccountBalance({ userId: loginUserId, accountId }), {
-    onSuccess: (data) => {
-      setInputVal(data);
-      setBalance(data);
-    },
-  });
+  const { isLoading: isLoadingData, isError: isErrorData } = useQuery(
+    'accountBalance',
+    () => accountApi.getAccountBalance({ userId: loginUserId, accountId }),
+    {
+      onSuccess: (data) => {
+        setInputVal(data);
+        setBalance(data);
+      },
+      onError: (e) => {
+        if (e === 401) {
+          navigate('/', { replace: true });
+        }
+      },
+    }
+  );
 
   const navigate = useNavigate();
   const {
@@ -42,7 +47,11 @@ const useBalanceModify = ({ balanceId, accountId }: { balanceId: number; account
     onSuccess: () => {
       handleModifyInput(false);
       navigate(0);
-      // refetch();
+    },
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
     },
   });
   const handleBalanceModify = () => {

--- a/src/hooks/useBanksData.tsx
+++ b/src/hooks/useBanksData.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { useQuery } from 'react-query';
 
@@ -9,12 +9,19 @@ import { goalApi } from '../apis/client';
 import { banksInfo } from '../recoil/accntAtoms';
 
 function useBanksData() {
-  const { data: banksData } = useQuery<Array<IBank>>('getBanks', () => goalApi.getBanks());
   const setBanksInfo = useSetRecoilState(banksInfo);
-  useEffect(() => {
-    if (!banksData) return;
-    setBanksInfo(banksData.slice(2, -1));
-  }, [banksData]);
+  const navigate = useNavigate();
+  useQuery<Array<IBank>>('getBanks', () => goalApi.getBanks(), {
+    select: (data) => data.slice(2, -1),
+    onSuccess: (data) => {
+      setBanksInfo(data);
+    },
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
+    },
+  });
 
   return;
 }

--- a/src/hooks/useGoalDetailData.tsx
+++ b/src/hooks/useGoalDetailData.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { useQuery } from 'react-query';
 
@@ -27,6 +28,7 @@ const useGoalDetailData = ({ loginUserId, goalId }: useGoalStateProps) => {
   const [accountId, setAccountId] = useState<number>(0);
   const [balanceId, setBalanceId] = useState<number>(0);
   const setGoalDetail = useSetRecoilState(goalDetail);
+  const navigate = useNavigate();
   const { isLoading, data, isError } = useQuery<IGoalDetail>('goalDetail', () => fetchGoalDetail(goalId), {
     onSuccess: (data) => {
       setGoalDetail(data);
@@ -35,6 +37,11 @@ const useGoalDetailData = ({ loginUserId, goalId }: useGoalStateProps) => {
       setIsWorking(isWorking(new Date(data.startDate), new Date(data.endDate)));
       setAccountId(accountIdFinder(data.members, loginUserId));
       setBalanceId(balanceIdFinder(data.members, loginUserId));
+    },
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
     },
   });
 

--- a/src/hooks/useGoalModify.tsx
+++ b/src/hooks/useGoalModify.tsx
@@ -29,6 +29,11 @@ const useGoalModify = ({ goalId }: { goalId: number }) => {
 
       setTimeout(() => navigate(`/goals/${goalId}`, { replace: true }), 2000);
     },
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
+    },
   });
 
   const savedPostGoal = useRecoilValue(postGoal);

--- a/src/hooks/useJoinGoal.tsx
+++ b/src/hooks/useJoinGoal.tsx
@@ -11,7 +11,12 @@ const useJoinGoal = ({ goalId }: { goalId: number }) => {
     isError,
   } = useMutation('joinGoal', goalApi.joinGoal, {
     onSuccess: () => {
-      setTimeout(() => navigate(`/goals/${goalId}`));
+      setTimeout(() => navigate(`/goals/${goalId}`), 2000);
+    },
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
     },
   });
 

--- a/src/hooks/usePostGoal.tsx
+++ b/src/hooks/usePostGoal.tsx
@@ -16,6 +16,11 @@ const usePostGoal = ({ accountId }: { accountId: number }) => {
       onSuccess: (data) => {
         setTimeout(() => navigate(`/goals/${data}`), 2000);
       },
+      onError: (e) => {
+        if (e === 401) {
+          navigate('/', { replace: true });
+        }
+      },
     }
   );
   const handlePostGoal = () => {

--- a/src/hooks/useUserGoalsData.tsx
+++ b/src/hooks/useUserGoalsData.tsx
@@ -46,9 +46,8 @@ const useUserGoalsData = ({ getUserId }: { getUserId: number }) => {
       setTotalCnt(getTotalCnt(data));
     },
     onError: (e) => {
-      console.log('get user goals error:', e);
       if (e === 401) {
-        navigate('/');
+        navigate('/', { replace: true });
       }
     },
   });

--- a/src/hooks/useUserProfileData.tsx
+++ b/src/hooks/useUserProfileData.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -12,6 +12,7 @@ const useUserProfileData = ({ getUserId }: { getUserId: number }) => {
   const loginUserId = useRecoilValue(userId);
   const isLoginUser = loginUserId === userId;
   const setUserProfile = useSetRecoilState(userProfile);
+  const navigate = useNavigate();
   const {
     isLoading,
     isError,
@@ -20,6 +21,11 @@ const useUserProfileData = ({ getUserId }: { getUserId: number }) => {
     onSuccess: (data) => {
       if (!isLoginUser) return;
       setUserProfile(data);
+    },
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
     },
   });
 

--- a/src/pages/DetailGoal.tsx
+++ b/src/pages/DetailGoal.tsx
@@ -17,7 +17,6 @@ import ParticipantSection from '../components/goal/detail/ParticipantSection';
 import { userId } from '../recoil/userAtoms';
 
 import useGoalDetailData from '../hooks/useGoalDetailData';
-import useGoalState from '../hooks/useGoalState';
 
 const setButton = (
   goalId: number,
@@ -58,7 +57,7 @@ const DetailGoal = () => {
   } = useGoalDetailData({ loginUserId, goalId });
 
   if (isLoading || !data) return <>Loading...</>;
-  if (isError) return <Navigate to='/' />;
+  if (isError) return <>Error</>;
 
   return (
     <Wrapper>

--- a/src/pages/SelectAccnt.tsx
+++ b/src/pages/SelectAccnt.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
@@ -50,7 +50,7 @@ const SelectAccnt = () => {
   const navigate = useNavigate();
 
   if (isLoading || !accounts) return <>Loading...</>;
-  if (isError) return <Navigate to='/' />;
+  if (isError) return <>Error</>;
 
   return (
     <Wrapper>


### PR DESCRIPTION
# 토큰 만료 에러(401) 수신 시 처리 로직 통일 (#110)
## 구현 상세
* 서버의 요청에 대한 응답으로 401 에러 수신 시, axios interceptor에서 localStorage의 accessToken 삭제 처리 하므로, react-query의 `onError` 동작에 redirect  페이지로 이동하도록 로직 통일. redirect로 이동하면, localStorage의 accesstoken을 확인하여 사용자 권한에 알맞는 페이지로 이동. 