### PR TITLE
FIX: fix detail goal page to only scroll on participant list overflow

### DIFF
--- a/src/components/goal/detail/ParticipantSection.tsx
+++ b/src/components/goal/detail/ParticipantSection.tsx
@@ -42,6 +42,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   gap: 20px;
   width: 100%;
+  height: 100%;
 `;
 
 const TopContent = styled.div`

--- a/src/components/goal/goalDetail/group/ParticipantList.tsx
+++ b/src/components/goal/goalDetail/group/ParticipantList.tsx
@@ -22,9 +22,9 @@ const ParticipantList = ({ createdUserId, members }: IParticipnatListProps) => {
   return (
     <Wrapper>
       <Type>목표 개설자</Type>
-      {creator}
+      <CardWrapper>{creator}</CardWrapper>
       <Type>목표 참여자</Type>
-      {participants.length === 0 ? <Info>아직 참여자가 없습니다</Info> : participants}
+      <ListWrapper>{participants.length === 0 ? <Info>아직 참여자가 없습니다</Info> : participants}</ListWrapper>
     </Wrapper>
   );
 };
@@ -39,7 +39,6 @@ const Wrapper = styled.div`
   width: calc(100% - 40px);
   height: calc(100% - 16px);
   border-radius: 16px;
-  overflow-y: auto;
   background-color: white;
 `;
 
@@ -47,6 +46,18 @@ const Type = styled.div`
   width: 100%;
   font: ${(props) => props.theme.captionC1};
   color: ${(props) => props.theme.gray600};
+`;
+
+const CardWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+`;
+
+const ListWrapper = styled(CardWrapper)`
+  gap: 8px;
+  overflow-y: auto;
 `;
 
 const Info = styled.div`

--- a/src/pages/DetailGoal.tsx
+++ b/src/pages/DetailGoal.tsx
@@ -111,9 +111,8 @@ const Wrapper = styled.div`
 const DetailGoalWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 20px;
   width: 100%;
-
   height: 100%;
 `;
 
@@ -122,11 +121,11 @@ const TopContent = styled.div`
   flex-direction: column;
   gap: 4px;
   width: 100%;
-  height: 100%;
 `;
 
 const BottomContent = styled(TopContent)`
   gap: 20px;
+  overflow-y: hidden;
 `;
 
 const GoalButtonSet = styled.div`

--- a/src/shared/AuthLayout.tsx
+++ b/src/shared/AuthLayout.tsx
@@ -47,12 +47,12 @@ const Wrapper = styled.div`
   position: relative;
   width: 100vw;
   height: 100vh;
+  overflow: hidden;
 `;
 
 const Body = styled.div<{ height: string }>`
   width: 100%;
   height: ${(props) => `calc(100vh - ${props.height})`};
-  overflow-y: auto;
   background-color: white;
 `;
 


### PR DESCRIPTION
# 목표 상세 페이지 화면 스크롤이 생기는 문제 수정
## 문제 상황
* 목표 상세 페이지에 참여자 목록이 길어지면 화면 전체가 스크롤 처리됨

## 원인
* Layout 전체 화면에 overflow 관련 처리가 되어 있지 않음. 
* Layout Body에 overflow auto 처리되어 있음
* 참여자 리스트 컴포넌트에 overflow 처리가 되어 있지 않음.

## 변경 사항
* Layout의 전체 화면 높이를 벗어나는 콘텐츠는 hidden 처리
* 목표 상세의 참여자 정보를 표시하는 영역 컴포넌트에 참여자 리스트만 overflow 에 스크롤이 생기도록 수정