### PR TITLE
FIX: fix post goal page not working flex space between button and content bug

### DIFF
--- a/src/components/goal/post/GoalInfoInput.tsx
+++ b/src/components/goal/post/GoalInfoInput.tsx
@@ -223,8 +223,10 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 20px;
   width: 100%;
   height: 100%;
+  overflow-y: auto;
 `;
 
 const ContentWrapper = styled.div`

--- a/src/pages/CreateGoalData.tsx
+++ b/src/pages/CreateGoalData.tsx
@@ -25,7 +25,6 @@ const Wrapper = styled.div`
   flex-direction: column;
   width: calc(100% - 44px);
   height: calc(100% - 48px);
-  overflow-y: auto;
   background-color: white;
 `;
 


### PR DESCRIPTION
# 목표 생성 페이지 화면 레이아웃 버그 수정
## 문제 상황
* 페이지 내용이 화면보다 길어지면 목표 생성하기 버튼과 컨텐츠 간의 간격이 붙어서 보이는 문제 발생
* overflow를 부모 요소에 지정하면, 부모 요소의 하단 padding이 화면 내에 포함되지 않는 문제 발생

## 원인
*  flex space between으로 버튼과 컨텐츠 가 화면의 양 끝 단에 붙어 보이도록 처리함
*  overflow 되는 상황에서는 요소 내에 여분의 간격이 없으므로 간격이 붙어서 나타남

## 해결 방안
* gap  값을 지정해두어서, 최소 간격을 유지할 수 있도록 수정
* auto 를 gap이 있는 요소에 발생하도록 수정하여 padding이 화면 내에 유지되면서 overflow가 일어날 수 있도록 수정