### PR TITLE
FEAT: add prepare page component and adjust to chat page path

### DIFF
--- a/src/components/goal/goalDetail/GoalDeleteButton.tsx
+++ b/src/components/goal/goalDetail/GoalDeleteButton.tsx
@@ -5,7 +5,6 @@ import TextButton from '../../common/elem/TextButton';
 
 import { goalApi } from '../../../apis/client';
 
-// TODO : 공통 버튼 컴포넌트 리팩터링
 const GoalDeleteButton = ({ goalId }: { goalId: number }) => {
   const { mutate } = useMutation('deleteGoal', () => goalApi.deleteGoal(goalId));
 

--- a/src/hooks/useHeaderState.tsx
+++ b/src/hooks/useHeaderState.tsx
@@ -13,7 +13,7 @@ const useHeaderState = ({ pathname }: { pathname: string }) => {
 
   const [showChatBtn, setShowChatBtn] = useState<boolean>(false);
   const handleChatClick = () => {
-    console.log('채팅 페이지로 이동');
+    navigate('/chats');
   };
 
   const [showPrevBtn, setShowPrevBtn] = useState<boolean>(false);
@@ -59,6 +59,10 @@ const useHeaderState = ({ pathname }: { pathname: string }) => {
       return;
     }
     if (pathname.includes('/goals/') && !pathname.includes('lookup') && !pathname.includes('post')) {
+      showPrevOnly();
+      return;
+    }
+    if (pathname.includes('/chats')) {
       showPrevOnly();
       return;
     }

--- a/src/hooks/useNavigateState.tsx
+++ b/src/hooks/useNavigateState.tsx
@@ -42,6 +42,7 @@ const useNavigateState = ({ pathname, userId }: useNavigateStateProps) => {
   useEffect(() => {
     if (pathname.includes('/goals/') && !pathname.includes('lookup')) return setShow(false);
     if (pathname.includes('/accounts')) return setShow(false);
+    if (pathname.includes('/chats')) return setShow(false);
 
     setShow(true);
     handleMenuSelect(pathMenuConverter(pathname));

--- a/src/pages/Prepare.tsx
+++ b/src/pages/Prepare.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Info from '../components/common/alert/Info';
+
+const Prepare = () => {
+  return (
+    <Wrapper>
+      <Info>서비스 준비 중입니다.</Info>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+export default Prepare;

--- a/src/shared/AuthLayout.tsx
+++ b/src/shared/AuthLayout.tsx
@@ -26,7 +26,11 @@ const AuthLayout = () => {
 
   useEffect(() => {
     if (!headerRef.current) return;
-    if ((pathname.includes('/goals/') && !pathname.includes('lookup')) || pathname.includes('/accounts')) {
+    if (
+      (pathname.includes('/goals/') && !pathname.includes('lookup')) ||
+      pathname.includes('/accounts') ||
+      pathname.includes('/chats')
+    ) {
       return setHeaderNavHeight(headerRef.current.clientHeight);
     }
     setHeaderNavHeight(headerRef.current.clientHeight + 88);

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -25,6 +25,7 @@ import ModifyGoal from '../pages/ModifyGoal';
 import LookupGoals from '../pages/LookupGoals';
 import SearchGoals from '../pages/SearchGoals';
 import DetailUser from '../pages/DetailUser';
+import Prepare from '../pages/Prepare';
 
 const Router = () => {
   return (
@@ -56,6 +57,7 @@ const Router = () => {
           <Route path='/goals/lookup' element={<LookupGoals />} />
           <Route path='/goals/lookup/search' element={<SearchGoals />} />
           <Route path='/users/:id' element={<DetailUser />} />
+          <Route path='/chats' element={<Prepare />} />
         </Route>
         <Route path='/' element={<Redirect />} />
       </Routes>


### PR DESCRIPTION
# 서비스 준비 중 페이지 구현 (#123)
## 구현 상세
* `src/pages/Prepare.tsx`: 서비스 준비 중입니다 안내 문구를 페이지 전체에 표시하는 페이지 구현

## 변경 사항
* `src/hooks/useHeaderState.tsx`: 채팅 목록 페이지 이동 기능 구현
* `src/hooks/useNavigateState.tsx`: 채팅 페이지 이동 시 네비게이션 표시하지 않도록 수정
* `src/shared/AuthLayout.tsx`: 채팅 페이지 이동 시 페이지 레이아웃 Body 높이 값 재계산하도록 수정
* `src/shared/Router.tsx`: 채팅 목록 페이지 경로 추가