### PR TITLE
FIX: fix use goal state hook to set goal state on props data change

### DIFF
--- a/src/hooks/useGoalState.tsx
+++ b/src/hooks/useGoalState.tsx
@@ -12,7 +12,7 @@ function useGoalState({ startDate, endDate }: { startDate: Date; endDate: Date }
     if (startDate.getTime() > new Date().getTime()) setState(GoalState.waiting);
     else if (endDate.getTime() > new Date().getTime()) setState(GoalState.working);
     else setState(GoalState.done);
-  }, []);
+  }, [startDate, endDate]);
 
   return { state };
 }


### PR DESCRIPTION
# 목표의 진행 상태를 반환하는 훅 버그 수정
## 문제 상황
* 목표 카드 필터링 시, 목표의 상태 태그가 잘못 표시되는 문제

## 원인
* 재 랜더링 될 때마다 목표 상태 훅이 상태 state를 재계산 하지 않음

## 변경 사항
startDate, endDate props 입력값이 변경될 때마다 상태 state를 재계산 하도록 수정