### PR TITLE
FIX: fix goal join button to disable account type select option on current version

### DIFF
--- a/src/components/goal/goalDetail/group/JoinButton.tsx
+++ b/src/components/goal/goalDetail/group/JoinButton.tsx
@@ -4,14 +4,20 @@ import styled from 'styled-components';
 import TextButton from '../../../common/elem/TextButton';
 import ModalBox from '../../../common/elem/ModalBox';
 import CloseIconBtn from '../../../common/elem/btn/CloseIconBtn';
-import ToggleSelectBox from '../../../common/elem/ToggleSelectBox';
+// TODO: 실계좌 기능 오픈
+// import ToggleSelectBox from '../../../common/elem/ToggleSelectBox';
 import AccountSelect from '../../../account/AccountSelectSection';
 
 import useAccountsData from '../../../../hooks/useAccountsData';
 import useJoinGoalModal from '../../../../hooks/useJoinGoalModal';
+import {
+  availAutoAccountFinder,
+  isAutoAccountAddable,
+  isManualAccountAddable,
+} from '../../../../utils/accountInfoChecker';
 
 const JoinButton = ({ goalId }: { goalId: number }) => {
-  const { isLoading, accounts, isError } = useAccountsData();
+  const { isLoading, isError, accounts } = useAccountsData();
 
   const {
     showOption,
@@ -19,7 +25,8 @@ const JoinButton = ({ goalId }: { goalId: number }) => {
     selectedAccntId,
     handleJoinStart,
     handleJoinEnd,
-    handleSelectOption,
+    // TODO: 실계좌 기능 오픈
+    // handleSelectOption,
     handleSelectOptionDone,
     handleSelectAccnt,
     handleSelectAccntDone,
@@ -34,28 +41,48 @@ const JoinButton = ({ goalId }: { goalId: number }) => {
       <ModalBox show={showOption}>
         <CloseIconBtn closeHandler={handleJoinEnd} />
         <Content>
-          <ToggleSelectBox
+          {isManualAccountAddable(accounts) ? (
+            <>
+              <Info>모은 금액은 직접 입력하여 업데이트를 해주세요.</Info>
+              {/* TODO: 실계좌 기능 오픈 */}
+              {/* <ToggleSelectBox
             title='계좌 잔액 직접 입력'
             description='계좌를 연결하지 않고 계좌 잔액을 직접 입력합니다.'
             initVal={false}
             selectHandler={handleSelectOption}
-          />
-          <TextButton text='다음' onClickHandler={handleSelectOptionDone} />
+          /> */}
+              <TextButton text='다음' onClickHandler={handleSelectOptionDone} />
+            </>
+          ) : (
+            <></>
+          )}
         </Content>
       </ModalBox>
       <ModalBox show={showAccounts}>
         <CloseIconBtn closeHandler={handleJoinEnd} />
         <Content>
-          {accounts.length === 0 ? (
-            <Info>연결된 계좌가 없습니다. 계좌를 연결하시겠습니까?</Info>
+          {isAutoAccountAddable(accounts) ? (
+            <>
+              {availAutoAccountFinder(accounts).length === 0 ? (
+                <Info>연결된 계좌가 없습니다. 계좌를 연결하시겠습니까?</Info>
+              ) : (
+                <AccountSelect accounts={availAutoAccountFinder(accounts)} accountSelectHandler={handleSelectAccnt} />
+              )}
+              <TextButton
+                text={accounts.length === 0 ? '계좌 연결하기' : '참여 완료하기'}
+                onClickHandler={handleSelectAccntDone}
+                isDisabled={accounts.length === 0 ? false : !selectedAccntId}
+              />
+            </>
           ) : (
-            <AccountSelect accounts={accounts} accountSelectHandler={handleSelectAccnt} />
+            <>
+              <Info>
+                등록한 계좌를 이미 사용 중입니다.
+                <br />
+                계좌는 최대 1개까지 등록할 수 있습니다.
+              </Info>
+            </>
           )}
-          <TextButton
-            text={accounts.length === 0 ? '계좌 연결하기' : '참여 완료하기'}
-            onClickHandler={handleSelectAccntDone}
-            isDisabled={accounts.length === 0 ? false : !selectedAccntId}
-          />
         </Content>
       </ModalBox>
     </>

--- a/src/hooks/useJoinGoalModal.tsx
+++ b/src/hooks/useJoinGoalModal.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router-dom';
 
 const useJoinGoalModal = ({ goalId }: { goalId: number }) => {
   const [showOption, setShowOption] = useState<boolean>(false);
-  const [isManual, setIsManual] = useState<boolean>(false);
+  // TODO: 실계좌 기능 오픈
+  const [isManual, setIsManual] = useState<boolean>(true);
   const handleSelectOption = (isTrue: boolean) => {
     setIsManual(isTrue);
   };


### PR DESCRIPTION
# 목표 참여 시 직접 입력 계좌 설정 옵션 숨기도록 수정 (#125)
## 변경 사항
* 목표 참여 버튼 클릭 시, 계좌 타입 설정 옵션 대신, 직접 입력 방식에 대한 안내 문구 표시
* 직접 입력 계좌를 추가할 수 없는 경우, 추가 불가능에 대한 안내 문구 표시
* 직접 입력 계좌를 선택한 것처럼 default 값 수정