### PR TITLE
FIX: fix group join button to show alert on manual account is not addable

### DIFF
--- a/src/components/goal/goalDetail/group/JoinButton.tsx
+++ b/src/components/goal/goalDetail/group/JoinButton.tsx
@@ -54,7 +54,18 @@ const JoinButton = ({ goalId }: { goalId: number }) => {
               <TextButton text='다음' onClickHandler={handleSelectOptionDone} />
             </>
           ) : (
-            <></>
+            <>
+              <Info>
+                최대 목표 개수만큼 진행 중이에요.
+                <br />
+                아쉽지만 다음에 함께해요.👋
+                <SubInfo>
+                  목표는 최대 10개까지 동시 진행할 수 있습니다.
+                  <br />
+                  현재 진행 중인 목표가 완료된 이후, 목표 생성 및 참여가 가능합니다.
+                </SubInfo>
+              </Info>
+            </>
           )}
         </Content>
       </ModalBox>
@@ -97,7 +108,14 @@ const Content = styled.div`
 `;
 
 const Info = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
   word-break: keep-all;
+  font: ${(props) => props.theme.paragraphsP1M};
+`;
+
+const SubInfo = styled(Info)`
   font: ${(props) => props.theme.captionC1};
 `;
 


### PR DESCRIPTION
# 목표 참여 버튼 클릭 시, 직접 입력 계좌 추가 불가능 안내 문구 표시하도록 수정
## 문제 상황
* 목표 참여 시, 직접 입력 계좌가 10개까지 생성되었고, 모두 사용중일 때, 계좌 추가가 불가능하므로 목표 참여가 불가능함을 알려주는 문구가 표시되지 않음.

## 변경 사항
* 알림 문구 추가