### PR TITLE
FIX: fix post goal page to adjust using only manual account

### DIFF
--- a/src/components/goal/post/GoalInfoInput.tsx
+++ b/src/components/goal/post/GoalInfoInput.tsx
@@ -79,10 +79,11 @@ function GoalInfoInput({ isGroup, initVal }: GoalInfoInputProps) {
     type: '인원',
   });
 
-  const [isManual, setisManual] = useState<boolean>(false);
-  const handleSelectisAuto = (isTrue: boolean) => {
-    setisManual(isTrue);
-  };
+  // TODO: 실계좌 기능 오픈
+  const [isManual, setisManual] = useState<boolean>(true);
+  // const handleSelectisAuto = (isTrue: boolean) => {
+  //   setisManual(isTrue);
+  // };
 
   const [isPrivate, setIsPrivate] = useState<boolean>(initVal.isPrivate);
   const handleSelectIsPrivate = (isTrue: boolean) => {
@@ -202,7 +203,8 @@ function GoalInfoInput({ isGroup, initVal }: GoalInfoInputProps) {
         ) : (
           <></>
         )}
-        <AccntToggle initVal={isManual} changeHandler={handleSelectisAuto} />
+        {/* TODO: 실계좌 기능 오픈 */}
+        {/* <AccntToggle initVal={isManual} changeHandler={handleSelectisAuto} /> */}
         {isGroup ? (
           <></>
         ) : (

--- a/src/pages/CreateGoalData.tsx
+++ b/src/pages/CreateGoalData.tsx
@@ -4,16 +4,34 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import GoalInfoInput from '../components/goal/post/GoalInfoInput';
+import Info from '../components/common/alert/Info';
+
+import useAccountsData from '../hooks/useAccountsData';
 
 import { postGoal } from '../recoil/goalsAtoms';
 
+import { isManualAccountAddable } from '../utils/accountInfoChecker';
+
 const CreateGoalData = () => {
   const { type } = useParams();
+  const { accounts } = useAccountsData();
   const savedPostGoal = useRecoilValue(postGoal);
 
   return (
     <Wrapper>
-      <GoalInfoInput isGroup={type === 'group'} initVal={savedPostGoal} />
+      {isManualAccountAddable(accounts) ? (
+        <GoalInfoInput isGroup={type === 'group'} initVal={savedPostGoal} />
+      ) : (
+        <Info type='error'>
+          최대 목표 개수만큼 진행 중입니다.
+          <SubInfo>
+            목표는 최대 10개까지 동시 진행할 수 있습니다.
+            <br />
+            현재 진행 중인 목표가 완료된 이후, <br />
+            목표 생성 및 참여가 가능합니다.
+          </SubInfo>
+        </Info>
+      )}
     </Wrapper>
   );
 };
@@ -26,6 +44,10 @@ const Wrapper = styled.div`
   width: calc(100% - 44px);
   height: calc(100% - 48px);
   background-color: white;
+`;
+
+const SubInfo = styled.div`
+  font: ${(props) => props.theme.paragraphsP3R};
 `;
 
 export default CreateGoalData;


### PR DESCRIPTION
# 목표 생성 페이지에 직접 입력 계좌 기능만 오픈 관련 수정 사항 반영
## 변경 사항
* 직접 입력 계좌 선택 옵션 가리기
* 직접 입력 계좌 추가 불가능한 경우, 생성 페이지로 넘어가지 않고 알림 문구 표시