### PR TITLE
FEAT: add get user badges method logic

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -14,7 +14,7 @@ import {
   IUpdateBalance,
   IModifyGoal,
   IBalance,
-  IUserProfile,
+  IUserBadge,
   IUpdateUserProfile,
 } from '../interfaces/interfaces';
 
@@ -106,50 +106,24 @@ export const userAPI = {
 
     return data.result;
   },
-  getUserBadges: async (userId: number) => {
-    const { data } = await tokenClient.get(`/users/${userId}/badges`);
-    // const data = [
-    //   {
-    //     title: '첫 목표 생성',
-    //     description: '처음 목표를 추가하면 획득할 수 있는 뱃지입니다.',
-    //     isObtained: true,
-    //   },
-    //   {
-    //     title: '첫 목표 달성',
-    //     description:
-    //       '마감 기한까지 목표 금액을 100% 달성하면 획득할 수 있는 뱃지입니다.',
-    //     isObtained: true,
-    //   },
-    //   {
-    //     title: '첫 그룹 참여',
-    //     description: '처음 그룹 목표에 참여하면 획득할 수 있는 뱃지입니다.',
-    //     isObtained: true,
-    //   },
-    //   {
-    //     title: '첫 그룹 모집',
-    //     description: '처음 그룹 목표를 모집하면 획득할 수 있는 뱃지입니다.',
-    //     isObtained: true,
-    //   },
-    //   {
-    //     title: '첫 그룹 목표 100% 달성',
-    //     description:
-    //       '그룹 목표에서 마감 기한까지 목표 금액을 100% 달성하면 획득할 수 있는 뱃지입니다.',
-    //     isObtained: true,
-    //   },
-    //   {
-    //     title: '3회 연속 도달',
-    //     description:
-    //       '목표 금액 100% 달성을 3번 연속하면 획득할 수 있는 뱃지입니다.',
-    //     isObtained: true,
-    //   },
-    // ];
-    return data;
+  getUserBadges: async (userId: number): Promise<Array<IUserBadge>> => {
+    const { data } = await tokenClient.get(`/users/badges/${userId}`);
+
+    return data.result;
   },
 
   patchEditUserProfile: async ({ userId, userProfile }: IUpdateUserProfile) => {
     const { data } = await tokenClient.patch(`/users/${userId}`, userProfile);
 
     return data;
+  },
+};
+
+export const badgeApi = {
+  getBadges: async () => {
+    const { data } = await tokenClient.get(`/users/badges`);
+
+    return data.result;
   },
 };
 

--- a/src/components/common/elem/BadgeBox.tsx
+++ b/src/components/common/elem/BadgeBox.tsx
@@ -1,14 +1,13 @@
-import React, { FunctionComponent, PropsWithChildren } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
-const BadgeBox: FunctionComponent<PropsWithChildren> = ({ children }) => {
-  return <Badge>{children}</Badge>;
+const BadgeBox = ({ imgURL }: { imgURL: string }) => {
+  return <Badge src={imgURL}></Badge>;
 };
 
-const Badge = styled.div`
+const Badge = styled.img`
   width: 100px;
   height: 100px;
-  background-color: ${(props) => props.theme.gray300};
 `;
 
 export default BadgeBox;

--- a/src/components/goal/MyFilteredGoals.tsx
+++ b/src/components/goal/MyFilteredGoals.tsx
@@ -9,9 +9,8 @@ import Icon from '../common/elem/Icon';
 import ModalBox from '../common/elem/ModalBox';
 import CloseIconBtn from '../common/elem/btn/CloseIconBtn';
 
+import useUserGoalsData from '../../hooks/useUserGoalsData';
 import useGoalsFilter, { FilterType } from '../../hooks/useGoalsFilter';
-
-import { IGoal } from '../../interfaces/interfaces';
 
 const filters = [FilterType.success, FilterType.fail, FilterType.waiting, FilterType.working];
 
@@ -30,25 +29,21 @@ const filterKR = (filterType: FilterType) => {
   }
 };
 
-interface MyFilteredGoalsProps {
-  isLoading: boolean;
-  isError: boolean;
-  goals: Array<IGoal>;
-}
-
-const MyFilteredGoals = ({ isLoading, isError, goals }: MyFilteredGoalsProps) => {
+const MyFilteredGoals = ({ userId }: { userId: number }) => {
   const [showFilters, setShowFilters] = useState<boolean>(false);
   const handleFilterModal = () => {
     setShowFilters(!showFilters);
   };
 
-  const { filterType, orderType, filtered, handleFilterType, handleOrderType } = useGoalsFilter({ goals });
+  const { isLoading, isError, filterType, orderType, filtered, handleFilterType, handleOrderType } = useGoalsFilter({
+    userId,
+  });
 
   return (
     <Wrapper>
       <TopContent>
         <Content>
-          <Total>{`전체 ${goals.length}개`}</Total>
+          <Total>{`전체 ${filtered.length}개`}</Total>
           <BtnWrapper>
             <FilterButton onClick={handleFilterModal}>
               <Label>필터</Label>

--- a/src/components/user/UserDetailTabSection.tsx
+++ b/src/components/user/UserDetailTabSection.tsx
@@ -3,30 +3,10 @@ import styled from 'styled-components';
 
 import MyFilteredGoals from '../goal/MyFilteredGoals';
 import MyFilteredBadges from '../badge/MyFilteredBadges';
-import Alert from '../common/alert/Alert';
-import LoadingMsg from '../common/elem/LoadingMsg';
-
-import { IBadge, IGoal } from '../../interfaces/interfaces';
 
 import useTab from '../../hooks/useTab';
 
-interface UserDetailTabProps {
-  isLoadingGoals: boolean;
-  isLoadingBadges: boolean;
-  isErrorGoals: boolean;
-  isErrorBadges: boolean;
-  goals?: Array<IGoal>;
-  badges: Array<IBadge>;
-}
-
-const UserDetailTab = ({
-  isLoadingGoals,
-  isLoadingBadges,
-  isErrorGoals,
-  isErrorBadges,
-  goals,
-  badges,
-}: UserDetailTabProps) => {
+const UserDetailTab = ({ userId }: { userId: number }) => {
   const { tabs, handleTabClick } = useTab();
 
   return (
@@ -39,24 +19,16 @@ const UserDetailTab = ({
         ))}
       </TabList>
       <ContentBox>
-        {isLoadingGoals || !goals ? (
-          <Alert showBgColor={true}>
-            <LoadingMsg />
-          </Alert>
-        ) : (
-          tabs.map((tab) => {
-            if (tab.isSelected) {
-              switch (tab.title) {
-                case '목표':
-                  return (
-                    <MyFilteredGoals key={tab.title} isLoading={isLoadingGoals} isError={isErrorGoals} goals={goals} />
-                  );
-                case '뱃지':
-                  return <MyFilteredBadges key={tab.title} />;
-              }
+        {tabs.map((tab) => {
+          if (tab.isSelected) {
+            switch (tab.title) {
+              case '목표':
+                return <MyFilteredGoals key={tab.title} userId={userId} />;
+              case '뱃지':
+                return <MyFilteredBadges key={tab.title} userId={userId} />;
             }
-          })
-        )}
+          }
+        })}
       </ContentBox>
     </Wrapper>
   );

--- a/src/hooks/useBadgesData.tsx
+++ b/src/hooks/useBadgesData.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { useQuery } from 'react-query';
+
+import { IBadge } from '../interfaces/interfaces';
+
+import { badgeApi } from '../apis/client';
+
+import { badges } from '../recoil/badgeAtoms';
+
+const useBadgesData = () => {
+  const navigate = useNavigate();
+  const setBadges = useSetRecoilState(badges);
+  useQuery<Array<IBadge>>('userBadges', () => badgeApi.getBadges(), {
+    onSuccess: (data) => {
+      setBadges(data);
+    },
+    onError: (e) => {
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
+    },
+  });
+};
+
+export default useBadgesData;

--- a/src/hooks/useUserBadgesData.tsx
+++ b/src/hooks/useUserBadgesData.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { useMutation } from 'react-query';
+
+import { IBadge, IUserBadge } from '../interfaces/interfaces';
+
+import { userAPI } from '../apis/client';
+
+import { badges } from '../recoil/badgeAtoms';
+
+const useUserBadgesData = ({ getUserId }: { getUserId: number }) => {
+  const savedBadges = useRecoilValue(badges);
+  const [userBadges, setUserBadges] = useState<Array<IBadge>>(savedBadges);
+
+  const navigate = useNavigate();
+  const { isLoading, isError } = useMutation<Array<IUserBadge>, unknown, number>(
+    'userBadges',
+    () => userAPI.getUserBadges(getUserId),
+    {
+      onSuccess: (data) => {
+        setUserBadges((prev) => {
+          const modified = [...prev];
+          modified.map((v) => {
+            for (const b of data) {
+              if (v.badgeId === b.badgeId) {
+                return (v.image = v.image.split('.png')[0] + '_color.png');
+              }
+            }
+
+            return v;
+          });
+
+          return modified;
+        });
+      },
+      onError: (e) => {
+        if (e === 401) {
+          navigate('/', { replace: true });
+        }
+      },
+    }
+  );
+
+  return { isLoading, isError, userBadges };
+};
+
+export default useUserBadgesData;

--- a/src/hooks/useUserGoalsData.tsx
+++ b/src/hooks/useUserGoalsData.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { useQuery } from 'react-query';
 
-import { userId, userGoals } from '../recoil/userAtoms';
+import { userId } from '../recoil/userAtoms';
 
 import { IGoal } from '../interfaces/interfaces';
 
@@ -25,25 +25,26 @@ const getTotalCnt = (goals: Array<IGoal>) => {
 const useUserGoalsData = ({ getUserId }: { getUserId: number }) => {
   const loginUserId = useRecoilValue(userId);
   const isLoginUser = loginUserId === getUserId;
-  const setUserGoals = useSetRecoilState(userGoals);
+  const [goals, setGoals] = useState<Array<IGoal>>([]);
   const [totalCnt, setTotalCnt] = useState<number>(0);
   const [successCnt, setSuccessCnt] = useState<number>(0);
   const [workingCnt, setWorkingCnt] = useState<number>(0);
   const navigate = useNavigate();
-  const { isLoading, isError, data } = useQuery<Array<IGoal>>('userGoals', () => userAPI.getUserGoals(getUserId), {
+  const { isLoading, isError } = useQuery<Array<IGoal>>('userGoals', () => userAPI.getUserGoals(getUserId), {
     onSuccess: (data) => {
       if (!isLoginUser) {
         const filtered = data.filter((goal) => !goal.isPrivate);
         setSuccessCnt(getSuccessCnt(filtered));
         setWorkingCnt(getWorkingCnt(filtered));
         setTotalCnt(getTotalCnt(filtered));
-        return filtered;
+        setGoals(data);
+        return;
       }
 
-      setUserGoals(data);
       setSuccessCnt(getSuccessCnt(data));
       setWorkingCnt(getWorkingCnt(data));
       setTotalCnt(getTotalCnt(data));
+      setGoals(data);
     },
     onError: (e) => {
       if (e === 401) {
@@ -52,7 +53,7 @@ const useUserGoalsData = ({ getUserId }: { getUserId: number }) => {
     },
   });
 
-  return { isLoading, isError, totalCnt, successCnt, workingCnt, data };
+  return { isLoading, isError, totalCnt, successCnt, workingCnt, goals };
 };
 
 export default useUserGoalsData;

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -195,6 +195,12 @@ export interface data {
 
 // badge
 export interface IBadge {
+  badgeId: number;
   title: string;
   description: string;
+  image: string;
+}
+
+export interface IUserBadge {
+  badgeId: number;
 }

--- a/src/pages/DetailUser.tsx
+++ b/src/pages/DetailUser.tsx
@@ -13,15 +13,7 @@ const DetailUser = () => {
   const navigate = useNavigate();
   if (!id) return <>잘못된 아이디 값입니다</>;
 
-  // TODO: get user badges data
-  const {
-    isLoading: isLoadingGoals,
-    isError: isErrorGoals,
-    totalCnt,
-    successCnt,
-    workingCnt,
-    data: goals,
-  } = useUserGoalsData({ getUserId: Number(id) });
+  const { totalCnt, successCnt, workingCnt } = useUserGoalsData({ getUserId: Number(id) });
 
   const handleUserEdit = () => {
     navigate(`/users/edit/${id}`);
@@ -42,14 +34,7 @@ const DetailUser = () => {
         </BtnWrapper>
       </TopContent>
       <UserContentBox topContentHeight={topContentHeight}>
-        <UserDetailTab
-          isLoadingGoals={isLoadingGoals}
-          isLoadingBadges={false}
-          isErrorGoals={isErrorGoals}
-          isErrorBadges={false}
-          goals={goals}
-          badges={[]}
-        />
+        <UserDetailTab userId={Number(id)} />
       </UserContentBox>
     </Wrapper>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
@@ -14,18 +14,20 @@ import { userId } from '../recoil/userAtoms';
 
 import useBanksData from '../hooks/useBanksData';
 import useUserGoalsData from '../hooks/useUserGoalsData';
+import useBadgesData from '../hooks/useBadgesData';
 
 const Home = () => {
   useBanksData();
   const { id } = useRecoilValue(userId);
-  const { isLoading, isError, data } = useUserGoalsData({ getUserId: Number(id) });
+  const { isLoading, isError, goals } = useUserGoalsData({ getUserId: Number(id) });
+  useBadgesData();
   const navigate = useNavigate();
 
   return (
     <Wrapper>
       <UserProfile />
       <ContentWrapper>
-        {isLoading || !data ? (
+        {isLoading || !goals ? (
           <Alert showBgColor={true}>
             <LoadingMsg />
           </Alert>
@@ -34,7 +36,7 @@ const Home = () => {
             <ErrorMsg />
           </Alert>
         ) : (
-          data
+          goals
             .filter(
               (goal) =>
                 new Date(goal.startDate).getTime() < new Date().getTime() &&

--- a/src/recoil/badgeAtoms.ts
+++ b/src/recoil/badgeAtoms.ts
@@ -1,0 +1,18 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+import { IBadge } from '../interfaces/interfaces';
+
+const { persistAtom } = recoilPersist();
+
+export const badges = atom<Array<IBadge>>({
+  key: 'badges',
+  default: [
+    {
+      badgeId: 0,
+      title: '',
+      description: '',
+      image: '',
+    },
+  ],
+  effects_UNSTABLE: [persistAtom],
+});


### PR DESCRIPTION
# 사용자 뱃지 조회 기능 구현 (#143)
## 구현 상세
* `src/apis/client.ts`: 전체 뱃지 조회, 사용자 획득 뱃지 조회 API 구현
* `src/components/badge/MyFilteredBadges.tsx`: 사용자 획득 뱃지 조회 로직 관리 훅을 사용하여 획득한 뱃지는 색상이 있는 이미지를 표시하도록 구현
* `src/components/common/elem/BadgeBox.tsx`: 이미지 태그로 변경하여 src 속성으로 이미지를 표시하도록 구현
* `src/hooks/useBadgesData.tsx`: 전체 뱃지 조회 로직 관리 훅 구현
* `src/hooks/useUserBadgesData.tsx`: 사용자 획득 뱃지 조회 로직 관리 훅 구현
* `src/hooks/useGoalsFilter.tsx`: 사용자 목표 필터링 로직 관리 훅 내에서 사용자 목표를 조회하도록 수정
* `src/interfaces/interfaces.ts`:  전체 뱃지 조회, 사용자 뱃지 조회 API의 응답 데이터 인터페이스 구현
* `src/recoil/badgeAtoms.ts`: 전체 뱃지 데이터를 저장할 atom 구현

## 변경 사항
* `src/components/goal/MyFilteredGoals.tsx`: 뱃지 탭과 통일성이 있도록, 탭 컴포넌트 내에서 사용자의 목표 조회와 필터링을 같이 하도록 수정
* `src/components/user/UserDetailTabSection.tsx`: 두가지 탭을 모두 관리하는 영역에서 목표 데이터를 넘기지 않도록 수정
* `src/hooks/useUserGoalsData.tsx`: 사용자 목표 조회 훅에서 atom 에 데이터를 저장하는 방식 사용하지 않도록 수정
* `src/pages/DetailUser.tsx`: 사용자 상세 페이지 단에서 사용자 목표를 조회하지 않도록 수정
* `src/pages/Home.tsx`: 홈페이지에서 전체 뱃지 조회 하도록 수정