### PR TITLE
FIX: fix search filtered goals to use total count of filtered goals

### DIFF
--- a/src/hooks/useSearchFilteredData.tsx
+++ b/src/hooks/useSearchFilteredData.tsx
@@ -19,6 +19,7 @@ const useSearchFilteredData = (params: ISearchFilter) => {
   const navigate = useNavigate();
   const setSearchFilters = useSetRecoilState(searchFilters);
   const [searchGoals, setSearchGoals] = useState<Array<ISearchGoal>>([]);
+  const [lastReqPage, setLastReqPage] = useState<number>(0);
   const [isLastPage, setIsLastPage] = useState<boolean>(false);
   const [totalCnt, setTotalCnt] = useState<number>(0);
   const { isLoading, isError, mutate } = useMutation<ISearchGoalResult, unknown, ISearchFilter>(
@@ -38,6 +39,8 @@ const useSearchFilteredData = (params: ISearchFilter) => {
           setSearchGoals((prev) => [...prev, ...data.result]);
         }
         setIsLastPage(data.isLastPage);
+        setTotalCnt(Number(data.count));
+        setLastReqPage(params.page);
       },
       onError: (e) => {
         if (e === 401) {
@@ -47,7 +50,7 @@ const useSearchFilteredData = (params: ISearchFilter) => {
     }
   );
   useEffect(() => {
-    mutate(params);
+    if (lastReqPage !== params.page) mutate(params);
   }, [params.keyword, params.status, params.ordered, params.sorted, params.page]);
 
   return { isLoading, isError, searchGoals, isLastPage, totalCnt };

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -209,6 +209,7 @@ export interface ISearchFilter {
 export interface ISearchGoalResult {
   result: Array<ISearchGoal>;
   isLastPage: boolean;
+  count: string;
 }
 
 export interface ISearchGoal {

--- a/src/pages/SearchGoals.tsx
+++ b/src/pages/SearchGoals.tsx
@@ -90,7 +90,10 @@ const SearchGoals = () => {
   const scrollBoxRef = useRef<HTMLDivElement>(null);
   const isScrollBottom = () => {
     if (!scrollBoxRef.current) return;
-    if (scrollBoxRef.current.scrollHeight - scrollBoxRef.current.scrollTop === scrollBoxRef.current.clientHeight) {
+    if (
+      Math.trunc(scrollBoxRef.current.scrollHeight - scrollBoxRef.current.scrollTop) ===
+      scrollBoxRef.current.clientHeight
+    ) {
       handlePageChange(page + 1);
       localStorage.setItem('scrollTop', String(scrollBoxRef.current.scrollTop));
     }


### PR DESCRIPTION
# 목표 검색 버그 수정
## 변경 사항
* 마지막 조회 페이지 정보를 저장하여, 마지막으로 조회한 페이지 값이 동일한 경우 다시 요청하지 않도록 수정
* 검색한 목표 목록의 전체 개수를 서버에서 받아 사용하도록 수정
* 무한 스크롤 기능이 소수점 차이로 동작하지 않는 문제 수정