### PR TITLE
FIX: fix user detail page to show other user's data

### DIFF
--- a/src/hooks/useHeaderState.tsx
+++ b/src/hooks/useHeaderState.tsx
@@ -1,5 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+import { userId } from '../recoil/userAtoms';
 
 const useHeaderState = ({ pathname }: { pathname: string }) => {
   const navigate = useNavigate();
@@ -54,13 +57,18 @@ const useHeaderState = ({ pathname }: { pathname: string }) => {
     setShowChatBtn(true);
   };
 
+  const { id } = useRecoilValue(userId);
   useEffect(() => {
     if (pathname === '/home') {
       showChatOnly();
       return;
     }
-    if (pathname.includes('/users') && !pathname.includes('/edit')) {
+    if (pathname === `/users/${id}`) {
       showChatOnly();
+      return;
+    }
+    if (pathname.includes('/users/')) {
+      showPrevOnly();
       return;
     }
     if (pathname.includes('/edit')) {

--- a/src/hooks/useNavigateState.tsx
+++ b/src/hooks/useNavigateState.tsx
@@ -1,5 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+import { userId } from '../recoil/userAtoms';
 
 export enum Menu {
   home,
@@ -9,11 +12,11 @@ export enum Menu {
   none,
 }
 
-const pathMenuConverter = (path: string) => {
+const pathMenuConverter = (path: string, userId: number) => {
   if (path.includes('/goals/lookup/search')) return Menu.search;
   if (path === '/goals/lookup') return Menu.lookup;
   if (path === '/home') return Menu.home;
-  if (path.includes('/users') && !path.includes('/edit')) return Menu.my;
+  if (path === `/users/${userId}`) return Menu.my;
 
   return Menu.none;
 };
@@ -55,11 +58,12 @@ const useNavigateState = ({ pathname, userId }: useNavigateStateProps) => {
     if (pathname.includes('/goals/') && !pathname.includes('lookup')) return setShow(false);
     if (pathname.includes('/accounts')) return setShow(false);
     if (pathname.includes('/users/edit')) return setShow(false);
+    if (pathname.includes('/users/') && pathname !== `/users/${userId}`) return setShow(false);
     if (pathname.includes('/chats')) return setShow(false);
 
     setShow(true);
-    handleMenuSelect(pathMenuConverter(pathname));
-    handlePageNavigate(pathMenuConverter(pathname));
+    handleMenuSelect(pathMenuConverter(pathname, userId));
+    handlePageNavigate(pathMenuConverter(pathname, userId));
   }, [pathname]);
 
   return { selectedMenu, show, handleMenuSelect, handlePageNavigate };

--- a/src/hooks/usePageName.tsx
+++ b/src/hooks/usePageName.tsx
@@ -1,4 +1,7 @@
 import { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { userId } from '../recoil/userAtoms';
 
 enum PageType {
   postGoal,
@@ -30,6 +33,7 @@ const PageKR = (type: PageType) => {
 };
 
 const usePageName = ({ pathname }: { pathname: string }) => {
+  const { id } = useRecoilValue(userId);
   const [pageType, setPageType] = useState<PageType>(PageType.none);
   useEffect(() => {
     switch (pathname) {
@@ -58,7 +62,7 @@ const usePageName = ({ pathname }: { pathname: string }) => {
       setPageType(PageType.editProfile);
       return;
     }
-    if (pathname.includes('/users')) {
+    if (pathname === `/users/${id}`) {
       setPageType(PageType.my);
       return;
     }

--- a/src/pages/DetailUser.tsx
+++ b/src/pages/DetailUser.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import UserDetailProfile from '../components/user/UserDetailProfile';
@@ -8,13 +9,16 @@ import TextButton from '../components/common/elem/TextButton';
 import useUserGoalsData from '../hooks/useUserGoalsData';
 import UserDetailTab from '../components/user/UserDetailTabSection';
 
+import { userId } from '../recoil/userAtoms';
+
 const DetailUser = () => {
   const { id } = useParams();
-  const navigate = useNavigate();
   if (!id) return <>잘못된 아이디 값입니다</>;
 
+  const { id: loginUserId } = useRecoilValue(userId);
   const { totalCnt, successCnt, workingCnt } = useUserGoalsData({ getUserId: Number(id) });
 
+  const navigate = useNavigate();
   const handleUserEdit = () => {
     navigate(`/users/edit/${id}`);
   };
@@ -30,7 +34,11 @@ const DetailUser = () => {
       <TopContent ref={ref}>
         <UserDetailProfile id={Number(id)} totalCnt={totalCnt} successCnt={successCnt} workingCnt={workingCnt} />
         <BtnWrapper>
-          <TextButton text='프로필 수정' bgColor='gray' onClickHandler={handleUserEdit} />
+          {loginUserId === Number(id) ? (
+            <TextButton text='프로필 수정' bgColor='gray' onClickHandler={handleUserEdit} />
+          ) : (
+            <></>
+          )}
         </BtnWrapper>
       </TopContent>
       <UserContentBox topContentHeight={topContentHeight}>

--- a/src/shared/AuthLayout.tsx
+++ b/src/shared/AuthLayout.tsx
@@ -1,9 +1,12 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { useNavigate, useLocation, Outlet } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import Header from './Header';
 import Navigation from './Navigation';
+
+import { userId } from '../recoil/userAtoms';
 
 const AuthLayout = () => {
   const accessToken = localStorage.getItem('accessToken');
@@ -24,13 +27,15 @@ const AuthLayout = () => {
   const headerRef = useRef<HTMLDivElement>(null);
   const [headerNavHeight, setHeaderNavHeight] = useState<number>(0);
 
+  const { id } = useRecoilValue(userId);
   useEffect(() => {
     if (!headerRef.current) return;
     if (
       (pathname.includes('/goals/') && !pathname.includes('lookup')) ||
       pathname.includes('/accounts') ||
       pathname.includes('/chats') ||
-      pathname.includes('/users/edit')
+      pathname.includes('/users/edit') ||
+      (pathname.includes('/users/') && pathname !== `/users/${id}`)
     ) {
       return setHeaderNavHeight(headerRef.current.clientHeight);
     }

--- a/src/shared/Header.tsx
+++ b/src/shared/Header.tsx
@@ -1,4 +1,4 @@
-import React, { Ref, forwardRef, useState } from 'react';
+import React, { Ref, forwardRef } from 'react';
 import { useLocation } from 'react-router';
 import styled from 'styled-components';
 


### PR DESCRIPTION
# 사용자 상세 페이지 다른 사용자 정보를 보여주지 못하는 버그 수정
## 문제 상황
* 다른 사용자의 프로필 페이지로 이동 할 때, 로그인한 사용자의 마이페이지로 이동하는 문제

## 원인
* 페이지 이동 경로에 '/users' 만 포함되어도 navigation bar에서 마이페이지를 클릭하여 이동한 것처럼 처리
* navigation bar에서 마이페이지 타입이 선택된 경우,  로그인한 사용자의 프로필 페이지로 이동

## 변경 사항
* 사용자 프로필 페이지 이동 시 페이지 경로가 '/users/{로그인한 사용자 아이디}' 와 일치해야 마이페이지로 이동한 것으로 처리
* 마이페이지가 아닌 사용자 프로필 페이지 이동 시, navigation bar 숨김 및 헤더에는 이전 버튼만 표시