### PR TITLE
FIX: fix detail goal page to show join button only on goal working status

### DIFF
--- a/src/hooks/useGoalDetailData.tsx
+++ b/src/hooks/useGoalDetailData.tsx
@@ -3,11 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { useQuery } from 'react-query';
 
-import { IGoalDetail } from '../interfaces/interfaces';
+import { GoalStatus, IGoalDetail } from '../interfaces/interfaces';
 
 import { goalApi } from '../apis/client';
 
-import { isGroup, isMember, isWorking } from '../utils/goalInfoChecker';
+import { getGoalStatus, isGroup, isMember } from '../utils/goalInfoChecker';
 import { accountIdFinder, balanceIdFinder } from '../utils/accountInfoChecker';
 
 import { goalDetail } from '../recoil/goalsAtoms';
@@ -24,7 +24,7 @@ const fetchGoalDetail = (goalId: string) => {
 const useGoalDetailData = ({ loginUserId, goalId }: useGoalStateProps) => {
   const [isGroupVal, setIsGroup] = useState<boolean>(false);
   const [isMemberVal, setIsMember] = useState<boolean>(false);
-  const [isWorkingVal, setIsWorking] = useState<boolean>(false);
+  const [status, setStatus] = useState<GoalStatus>(GoalStatus.proceeding);
   const [accountId, setAccountId] = useState<number>(0);
   const [balanceId, setBalanceId] = useState<number>(0);
   const setGoalDetail = useSetRecoilState(goalDetail);
@@ -34,7 +34,7 @@ const useGoalDetailData = ({ loginUserId, goalId }: useGoalStateProps) => {
       setGoalDetail(data);
       setIsGroup(isGroup(data.headCount));
       setIsMember(isMember(loginUserId, data.members));
-      setIsWorking(isWorking(new Date(data.startDate), new Date(data.endDate)));
+      setStatus(getGoalStatus(new Date(data.startDate), new Date(data.endDate)));
       setAccountId(accountIdFinder(data.members, loginUserId));
       setBalanceId(balanceIdFinder(data.members, loginUserId));
     },
@@ -45,7 +45,7 @@ const useGoalDetailData = ({ loginUserId, goalId }: useGoalStateProps) => {
     },
   });
 
-  return { isLoading, isError, data, isGroupVal, isMemberVal, isWorkingVal, accountId, balanceId };
+  return { isLoading, isError, data, isGroupVal, isMemberVal, status, accountId, balanceId };
 };
 
 export default useGoalDetailData;

--- a/src/hooks/useUserGoalsData.tsx
+++ b/src/hooks/useUserGoalsData.tsx
@@ -15,7 +15,11 @@ const getSuccessCnt = (goals: Array<IGoal>) => {
 };
 
 const getWorkingCnt = (goals: Array<IGoal>) => {
-  return goals.filter((goal) => new Date(goal.startDate).getTime() < new Date().getTime()).length;
+  return goals.filter(
+    (goal) =>
+      new Date(goal.startDate).getTime() < new Date().getTime() &&
+      new Date(goal.endDate).getTime() > new Date().getTime()
+  ).length;
 };
 
 const getTotalCnt = (goals: Array<IGoal>) => {

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -47,6 +47,12 @@ export interface IGoal {
   isPrivate: boolean;
 }
 
+export enum GoalStatus {
+  recruit,
+  proceeding,
+  done,
+}
+
 export interface IPostGoal {
   emoji: string;
   title: string;

--- a/src/pages/DetailGoal.tsx
+++ b/src/pages/DetailGoal.tsx
@@ -19,12 +19,13 @@ import ParticipantSection from '../components/goal/detail/ParticipantSection';
 import { userId } from '../recoil/userAtoms';
 
 import useGoalDetailData from '../hooks/useGoalDetailData';
+import { GoalStatus } from '../interfaces/interfaces';
 
 const setButton = (
   goalId: number,
   createdUserId: number,
   loginUserId: number,
-  isWorking: boolean,
+  status: GoalStatus,
   isGroup: boolean,
   isMember: boolean
 ) => {
@@ -32,10 +33,10 @@ const setButton = (
     return (
       <GoalButtonSet>
         <GoalModifyButton isGroup={isGroup} />
-        {isWorking ? <></> : <GoalDeleteButton goalId={goalId} />}
+        {status === GoalStatus.proceeding ? <></> : <GoalDeleteButton goalId={goalId} />}
       </GoalButtonSet>
     );
-  } else if (isGroup && !isWorking) {
+  } else if (isGroup && status === GoalStatus.recruit) {
     return (
       <GoalButtonSet>{isMember ? <WithDrawButton goalId={goalId} /> : <JoinButton goalId={goalId} />}</GoalButtonSet>
     );
@@ -53,7 +54,7 @@ const DetailGoal = () => {
     data,
     isGroupVal: isGroup,
     isMemberVal: isMember,
-    isWorkingVal: isWorking,
+    status,
     accountId,
     balanceId,
   } = useGoalDetailData({ loginUserId, goalId });
@@ -77,7 +78,11 @@ const DetailGoal = () => {
           />
           <GoalPeriodCard startDate={data.startDate} endDate={data.endDate} />
           <GoalDescCard description={data.description} />
-          {isMember && isWorking ? <GoalBalanceCard balanceId={balanceId} accountId={accountId} /> : <></>}
+          {isMember && status === GoalStatus.proceeding ? (
+            <GoalBalanceCard balanceId={balanceId} accountId={accountId} />
+          ) : (
+            <></>
+          )}
         </TopContent>
         <BottomContent>
           {isMember ? <GoalAccountInfo accountId={accountId} /> : <></>}
@@ -93,7 +98,7 @@ const DetailGoal = () => {
           )}
         </BottomContent>
       </DetailGoalWrapper>
-      {setButton(Number(goalId), data.userId, loginUserId, isWorking, isGroup, isMember)}
+      {setButton(Number(goalId), data.userId, loginUserId, status, isGroup, isMember)}
     </Wrapper>
   );
 };

--- a/src/utils/goalInfoChecker.ts
+++ b/src/utils/goalInfoChecker.ts
@@ -1,4 +1,4 @@
-import { IMemeberInfo } from '../interfaces/interfaces';
+import { GoalStatus, IMemeberInfo } from '../interfaces/interfaces';
 
 export const participantFinder = (members: Array<IMemeberInfo>, userId: number) => {
   const found = members.find((member) => member.userId === userId);
@@ -7,10 +7,12 @@ export const participantFinder = (members: Array<IMemeberInfo>, userId: number) 
   return participant;
 };
 
-export const isWorking = (startDate: Date, endDate: Date) => {
+export const getGoalStatus = (startDate: Date, endDate: Date): GoalStatus => {
   const today = new Date().getTime();
 
-  return !(today > endDate.getTime() || today < startDate.getTime());
+  if (today < startDate.getTime()) return GoalStatus.recruit;
+  if (today > startDate.getTime() && today < endDate.getTime()) return GoalStatus.proceeding;
+  return GoalStatus.done;
 };
 
 export const isGroup = (headCount: number) => {


### PR DESCRIPTION
# 목표 상세 페이지 참여하기 버튼 버그 수정
## 문제 상황
* 종료된 목표의 상세 페이지 이동 시 참여하기 버튼이 보이는 문제

## 원인
* 종료된 목표도 진행중이지 않은 목표로 판단하기 때문에 참여하기 버튼이 보임

## 변경 사항
* 목표 상태를 `recruit(모집중)`, `proceeding(진행중)`, `done(종료)` 로 나누어 진행중인 경우에만 참여하기 버튼이 보이도록 수정