### PR TITLE
FIX: fix badges tab component to use responsive column gap

### DIFF
--- a/src/components/badge/MyFilteredBadges.tsx
+++ b/src/components/badge/MyFilteredBadges.tsx
@@ -64,22 +64,22 @@ const MyFilteredBadges = ({ userId }: { userId: number }) => {
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 100%;
   height: 100%;
   overflow-y: auto;
 `;
 
 const Row = styled.div`
-  width: 100%;
   display: flex;
   flex-direction: row;
   row-gap: 20px;
-  column-gap: 35px;
+  column-gap: calc(10% / 2);
   flex-wrap: wrap;
 `;
 
 const BadgeBoxWrapper = styled.div`
-  width: 100px;
+  width: 30%;
   height: 100px;
 `;
 


### PR DESCRIPTION
# 뱃지 리스트 탭 디자인 수정
## 문제 상황
* 화면 너비가 늘어나면 뱃지가 한쪽으로 치우쳐서 배치됨

## 원인
* 뱃지 리스트의 column gap 값이 고정값임

## 변경 사항
* 뱃지 간의 간격이 화면 너비 변경과 함께 변화하도록 수정