### PR TITLE
FIX: fix search filtered goals to request on keyword change

### DIFF
--- a/src/hooks/useSearchFilteredData.tsx
+++ b/src/hooks/useSearchFilteredData.tsx
@@ -50,6 +50,7 @@ const useSearchFilteredData = (params: ISearchFilter) => {
     }
   );
   useEffect(() => {
+    if (lastReqPage === 1) mutate(params);
     if (lastReqPage !== params.page) mutate(params);
   }, [params.keyword, params.status, params.ordered, params.sorted, params.page]);
 


### PR DESCRIPTION
# 목표 검색 버그 수정
## 문제 상황
* 키워드 검색 시, 검색이 실행되지 않는 문제

## 원인
* 직전 요청 페이지와 현재 요청 페이지가 동일한 경우 검색 요청을 막고 있음

## 변경 사항
* 첫번째 페이지인 경우, 직전 요청 페이지와 동일한 경우에도 검색 가능하도록 수정