### PR TITLE
FIX: fix pinnumber page to handle sign in with isNewComer value

### DIFF
--- a/src/hooks/usePinNumberKeypad.tsx
+++ b/src/hooks/usePinNumberKeypad.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 
 interface PinNumberKeypadProps {
   PASSWORD_MAX_LENGTH: number;
-  accessToken: string | null;
+  isNewComer: boolean;
 }
 
-const usePinNumberKeypad = ({ PASSWORD_MAX_LENGTH, accessToken }: PinNumberKeypadProps) => {
+const usePinNumberKeypad = ({ PASSWORD_MAX_LENGTH, isNewComer }: PinNumberKeypadProps) => {
   const numberInit = Array.from({ length: 10 }, (v, k) => k);
 
   const [numbers, setNumbers] = useState(numberInit);
@@ -38,10 +38,9 @@ const usePinNumberKeypad = ({ PASSWORD_MAX_LENGTH, accessToken }: PinNumberKeypa
   }, [pinNumber1]);
 
   const handlePinNumberChange = (num: number) => {
-    if (accessToken === null) {
-      setLoginPinNumber(loginPinNumber + num.toString());
-    }
-    if (accessToken && pinNumber1.length !== PASSWORD_MAX_LENGTH) {
+    if (!isNewComer) return setLoginPinNumber(loginPinNumber + num.toString());
+
+    if (pinNumber1.length !== PASSWORD_MAX_LENGTH) {
       setPinNumber1(pinNumber1 + num.toString());
     } else {
       setPinNumber2(pinNumber2 + num.toString());

--- a/src/hooks/usePinNumberRepost.tsx
+++ b/src/hooks/usePinNumberRepost.tsx
@@ -14,13 +14,17 @@ const usePinNumberRepost = (loginPinNumber: string) => {
     try {
       const data = await userAPI.postAccessTokenByPinCode(loginPinNumber);
       localStorage.setItem('accessToken', data.accessToken);
+      localStorage.removeItem('isNewComer');
       setUserId({ id: jwtDecoder<MyToken>(data.accessToken).userId });
 
       navigate('/home');
     } catch (e) {
-      console.log('get access token error:', e);
       localStorage.removeItem('accessToken');
+      localStorage.removeItem('isNewComer');
       setUserId({ id: 0 });
+      if (e === 401) {
+        navigate('/', { replace: true });
+      }
     }
   };
 

--- a/src/hooks/usePinNumberSignupPost.tsx
+++ b/src/hooks/usePinNumberSignupPost.tsx
@@ -24,8 +24,10 @@ const usePinNumberSignupPost = ({
       onSuccess: () => {
         navigate('/welcome');
       },
-      onError: (error) => {
-        alert(error);
+      onError: (e) => {
+        if (e === 401) {
+          navigate('/', { replace: true });
+        }
       },
     }
   );

--- a/src/hooks/usePinNumberSignupPost.tsx
+++ b/src/hooks/usePinNumberSignupPost.tsx
@@ -7,11 +7,7 @@ interface PinNumberSignupPostProps {
   pinNumber2: string;
 }
 
-const usePinNumberSignupPost = ({
-  id,
-
-  pinNumber2,
-}: PinNumberSignupPostProps) => {
+const usePinNumberSignupPost = ({ id, pinNumber2 }: PinNumberSignupPostProps) => {
   const navigate = useNavigate();
 
   const { refetch } = useQuery(
@@ -22,6 +18,7 @@ const usePinNumberSignupPost = ({
     {
       enabled: false,
       onSuccess: () => {
+        localStorage.removeItem('isNewComer');
         navigate('/welcome');
       },
       onError: (e) => {

--- a/src/pages/GoogleLogin.tsx
+++ b/src/pages/GoogleLogin.tsx
@@ -21,7 +21,7 @@ const GoogleLogin = () => {
       const data = await userAPI.getGoogleSignup(code);
       localStorage.setItem('accessToken', data.accessToken);
       localStorage.setItem('refreshToken', data.refreshToken);
-
+      localStorage.setItem('isNewComer', data.newComer);
       setUserId({ id: jwtDecoder<MyToken>(data.accessToken).userId });
 
       if (data.newComer === true) {
@@ -33,6 +33,7 @@ const GoogleLogin = () => {
       console.log('google signup error:', e);
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
+      localStorage.removeItem('isNewComer');
     }
   };
   useEffect(() => {

--- a/src/pages/KakaoLogin.tsx
+++ b/src/pages/KakaoLogin.tsx
@@ -22,7 +22,7 @@ const KakaoLogin = () => {
 
       localStorage.setItem('accessToken', data.accessToken);
       localStorage.setItem('refreshToken', data.refreshToken);
-
+      localStorage.setItem('isNewComer', data.newComer);
       setUserId({ id: jwtDecoder<MyToken>(data.accessToken).userId });
 
       if (data.newComer === true) {
@@ -34,6 +34,7 @@ const KakaoLogin = () => {
       console.log('kakao signup error:', e);
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
+      localStorage.removeItem('isNewComer');
     }
   };
   useEffect(() => {

--- a/src/pages/NaverLogin.tsx
+++ b/src/pages/NaverLogin.tsx
@@ -21,7 +21,7 @@ const NaverLogin = () => {
       const data = await userAPI.getNaverSignup(code);
       localStorage.setItem('accessToken', data.accessToken);
       localStorage.setItem('refreshToken', data.refreshToken);
-
+      localStorage.setItem('isNewComer', data.newComer);
       setUserId({ id: jwtDecoder<MyToken>(data.accessToken).userId });
 
       if (data.newComer === true) {
@@ -33,6 +33,7 @@ const NaverLogin = () => {
       console.log('naver signup error:', e);
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
+      localStorage.removeItem('isNewComer');
     }
   };
   useEffect(() => {

--- a/src/pages/PinNumberPage.tsx
+++ b/src/pages/PinNumberPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
@@ -14,11 +14,16 @@ import usePinNumberRepost from '../hooks/usePinNumberRepost';
 const PinNumberPage = () => {
   const { id } = useRecoilValue(userId);
   const PASSWORD_MAX_LENGTH = 6;
-  const accessToken = localStorage.getItem('accessToken');
+  const storedIsNewComer = localStorage.getItem('isNewComer');
+  const [isNewComer, setIsNewComer] = useState<boolean>(false);
+  useEffect(() => {
+    if (storedIsNewComer === 'true') return setIsNewComer(true);
+    setIsNewComer(false);
+  }, [storedIsNewComer]);
 
   const { numbers, pinNumber1, pinNumber2, loginPinNumber, erasePinNumberOne, inputNums } = usePinNumberKeypad({
     PASSWORD_MAX_LENGTH,
-    accessToken,
+    isNewComer,
   });
 
   const { refetch: refetchPinNumber } = usePinNumberSignupPost({
@@ -29,34 +34,50 @@ const PinNumberPage = () => {
   const { getAccessToken } = usePinNumberRepost(loginPinNumber);
 
   useEffect(() => {
-    if (loginPinNumber.length === PASSWORD_MAX_LENGTH && accessToken === null) {
+    if (loginPinNumber.length === PASSWORD_MAX_LENGTH && !isNewComer) {
       getAccessToken();
     }
-    if (pinNumber2.length === PASSWORD_MAX_LENGTH && pinNumber2 === pinNumber1 && accessToken !== null) {
+    if (pinNumber2.length === PASSWORD_MAX_LENGTH && pinNumber2 === pinNumber1 && isNewComer) {
       refetchPinNumber();
     }
-  }, [pinNumber1, pinNumber2, accessToken]);
+  }, [loginPinNumber, pinNumber1, pinNumber2]);
 
   return (
     <Wrapper>
       <TextWrapper>
-        {accessToken && pinNumber1.length !== PASSWORD_MAX_LENGTH ? (
-          <Text>
-            <Logo type='small' size={52} />
-            &nbsp;에서 사용할 <br />
-            핀번호를 설정하세요.
-          </Text>
+        {!isNewComer ? (
+          <Text>핀번호를 입력해주세요.</Text>
         ) : (
-          <Text>핀번호를 확인해주세요.</Text>
+          <>
+            {pinNumber1.length !== PASSWORD_MAX_LENGTH ? (
+              <Text>
+                <Logo type='small' size={52} />
+                &nbsp;에서 사용할 <br />
+                핀번호를 설정하세요.
+              </Text>
+            ) : (
+              <Text>핀번호를 확인해주세요.</Text>
+            )}
+          </>
         )}
         <InputWrapper>
           <GuideText>숫자 6자리</GuideText>
           <RadioInputWrapper>
-            {accessToken === null && loginPinNumber.length !== PASSWORD_MAX_LENGTH
-              ? Array.from(loginPinNumber).map((pin) => <RadioInput key={pin} />)
-              : accessToken && pinNumber1.length !== PASSWORD_MAX_LENGTH
-              ? Array.from(pinNumber1).map((pin) => <RadioInput key={pin} />)
-              : Array.from(pinNumber2).map((pin) => <RadioInput key={pin} />)}
+            {!isNewComer ? (
+              <>
+                {loginPinNumber.length !== PASSWORD_MAX_LENGTH ? (
+                  Array.from(loginPinNumber).map((pin) => <RadioInput key={pin} />)
+                ) : (
+                  <></>
+                )}
+              </>
+            ) : (
+              <>
+                {pinNumber1.length !== PASSWORD_MAX_LENGTH
+                  ? Array.from(pinNumber1).map((v, i) => <RadioInput key={i} />)
+                  : Array.from(pinNumber2).map((v, i) => <RadioInput key={i} />)}
+              </>
+            )}
           </RadioInputWrapper>
         </InputWrapper>
       </TextWrapper>

--- a/src/shared/RefreshLayout.tsx
+++ b/src/shared/RefreshLayout.tsx
@@ -9,14 +9,18 @@ const RefreshLayout = () => {
   const navigate = useNavigate();
   const accessToken = localStorage.getItem('accessToken');
   const refreshToken = localStorage.getItem('refreshToken');
+  const IsNewComer = localStorage.getItem('isNewComer');
+
   useEffect(() => {
-    if (accessToken && refreshToken) {
-      navigate('/home');
-      return;
-    }
-    if (!accessToken && !refreshToken) {
-      navigate('/login');
-      return;
+    if (!IsNewComer) {
+      if (accessToken && refreshToken) {
+        navigate('/home');
+        return;
+      }
+      if (!accessToken && !refreshToken) {
+        navigate('/login');
+        return;
+      }
     }
   }, [accessToken, refreshToken]);
 

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -25,9 +25,9 @@ import LookupGoals from '../pages/LookupGoals';
 import SearchGoals from '../pages/SearchGoals';
 import DetailUser from '../pages/DetailUser';
 import EditUserProfile from '../pages/EditUserProfile';
-import Prepare from '../pages/Prepare';
 import UserSettings from '../pages/UserSettings';
 import WelcomePage from '../pages/WelcomePage';
+import Prepare from '../pages/Prepare';
 
 const Router = () => {
   return (


### PR DESCRIPTION
# 핀번호 입력 페이지 수정
## 문제 상황
* 처음 회원 가입 시에도 accessToken까지 발급을 받고, accessToken 값을 사용하여 핀번호를 등록해야하기 때문에 accessToken 값만으로 첫 회원 가입 여부를 판단할 수 없음

## 해결 방안
* 로그인시 서버에서 보내는 isNewComer 값을 localStorage 에 저장하여 새로 가입 여부를 판단하여 핀번호 등록 과정과 기존 핀번호 입력 과정을 분리함