### PR TITLE
FIX: fix modal box to inherit width from page view wrapper

### DIFF
--- a/src/components/common/elem/ModalBox.tsx
+++ b/src/components/common/elem/ModalBox.tsx
@@ -23,7 +23,7 @@ const Wrapper = styled.div<{ show: boolean }>`
   left: 0;
   z-index: 10;
   display: ${(props) => (props.show ? '' : 'none')};
-  width: 100vw;
+  width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
 `;


### PR DESCRIPTION
# 모달창 너비 버그 수정
## 문제 상황
* 모달창 너비가 모바일 화면 밖으로 벗어나는 문제

## 원인
* 모달창 너비가 화면 너비에 맞춰져 있음

## 변경 사항
* 모달창 너비를 모바일 화면 요소의 너비를 상속받도록 `%` 로 수정