### PR TITLE
FIX: fix edit user profile page to disable button on invalidate input value

### DIFF
--- a/src/pages/EditUserProfile.tsx
+++ b/src/pages/EditUserProfile.tsx
@@ -13,6 +13,7 @@ import { userId, userProfile } from '../recoil/userAtoms';
 
 const EditUserProfile = () => {
   const savedUserProfile = useRecoilValue(userProfile);
+  const savedDescription = !savedUserProfile.description ? '' : savedUserProfile.description;
   const {
     ref,
     imgURL,
@@ -70,7 +71,14 @@ const EditUserProfile = () => {
           </LabelBox>
         </UserContentBox>
       </TopContent>
-      <TextButton text='프로필 수정 완료' onClickHandler={() => handleProfileModify(uploadFile)} />
+      <TextButton
+        text='프로필 수정 완료'
+        onClickHandler={() => handleProfileModify(uploadFile)}
+        isDisabled={
+          nickname.length === 0 ||
+          (nickname === savedUserProfile.nickname && description === savedDescription && !uploadFile)
+        }
+      />
     </Wrapper>
   );
 };


### PR DESCRIPTION
# 사용자 프로필 수정 페이지의 입력값에 따라 수정 버튼 비활성화 하도록 수정
## 문제 상황
* 이름 값 입력 안했을 때, 수정 내용이 없을 때에도 수정 요청이 가능한 문제

## 해결 방안
* 이름 값 길이가 0일 때, 이름과 내용 모두 기존 값과 동일하고 선택한 이미지 파일이 없을 때 수정 버튼 비활성화