### PR TITLE
FIX: fix media query to rotate screen only in mobile sized screen

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -24,8 +24,10 @@ time, mark, audio, video {
 }
 
 @media (orientation: landscape) {
-  html {
-    transform: rotate(-90deg);
+  @media screen and (max-width: 700px) {
+    html {
+      transform: rotate(-90deg);
+    }
   }
 }
 


### PR DESCRIPTION
# 가로 모드에서 화면 회전 버그 수정
## 변경 사항
* 모바일 사이즈 화면에서만 가로 모드 시 화면이 회전되도록 수정