### PR TITLE
FIX: fix search keyword to request search goals on keyword change

### DIFF
--- a/src/components/goal/search/SearchResults.tsx
+++ b/src/components/goal/search/SearchResults.tsx
@@ -32,17 +32,17 @@ const SearchResults = ({ params, totalCntHandler }: SearchResultsProps) => {
     mutate: searchGoals,
     resetIsLastPage,
   } = useSearchGoalsData({ initVal: savedSearchGoals });
+
   // cursor is last goal's sorted type value (ex. amount, period, member(=headCount))
   // cursor is 0 on goal's sorted type is none
-  const [cursor, setCursor] = useState(0);
   // goalId is search result's last goal's goalId
+  const [cursor, setCursor] = useState(0);
   const [goalId, setGoalId] = useState(0);
   useEffect(() => {
     if (!savedIsLastPage) searchGoals({ ...params, cursor, goalId });
   }, [goalId]);
 
   useEffect(() => {
-    if (savedIsLastPage && new Date().getTime() - savedLastUpdate.getTime() < 30000) return;
     setCursor(0);
     setGoalId(0);
     resetIsLastPage();

--- a/src/hooks/useHeaderState.tsx
+++ b/src/hooks/useHeaderState.tsx
@@ -14,15 +14,25 @@ const useHeaderState = ({ pathname }: { pathname: string }) => {
   };
   const handleKeypress = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.code === 'Enter') {
-      handleSearchClick();
+      return navigate(
+        {
+          pathname: '/goals/lookup/search',
+          search: `?keyword=${keyword}`,
+        },
+        { replace: true }
+      );
     }
   };
+
   const handleSearchClick = () => {
     if (pathname.includes('/goals/lookup'))
-      return navigate({
-        pathname: '/goals/lookup/search',
-        search: `?keyword=${keyword}`,
-      });
+      return navigate(
+        {
+          pathname: '/goals/lookup/search',
+          search: `?keyword=`,
+        },
+        { replace: true }
+      );
     navigate('/goals/lookup');
   };
 
@@ -36,8 +46,10 @@ const useHeaderState = ({ pathname }: { pathname: string }) => {
 
   const [showPrevBtn, setShowPrevBtn] = useState<boolean>(false);
   const handlePrevClick = () => {
+    if (pathname.includes('/goals/lookup/search?keyword=') && pathname.split('keyword=')[1] !== undefined) {
+      return navigate({ pathname: '/goals/lookup/search', search: `?keyword=` }, { replace: true });
+    }
     if (pathname !== '/goals/lookup') {
-      setKeyword('');
       return navigate(-1);
     }
 
@@ -119,6 +131,9 @@ const useHeaderState = ({ pathname }: { pathname: string }) => {
       return;
     }
     if (pathname === '/goals/lookup/search') {
+      if (pathname.split('keyword=')[1] === undefined) {
+        setKeyword('');
+      }
       setShowSearchBar(true);
       setShowPrevBtn(true);
       setShowSearchBtn(false);


### PR DESCRIPTION
# 키워드 검색 버그 수정
## 변경 사항
* `src/components/goal/search/SearchResults.tsx`: 파라미터 변경 시 검색 요청하도록 수정
* `src/hooks/useHeaderState.tsx`: 검색 페이지에서 키워드 검색 시, 과거 검색 내역 navigation history에 쌓이지 않도록 수정