### PR TITLE
FIX: fix scroll restoration feature bug to restore scroll position correctly

### DIFF
--- a/src/components/goal/GroupGoalCard.tsx
+++ b/src/components/goal/GroupGoalCard.tsx
@@ -10,8 +10,6 @@ import { dateStringTranslator } from '../../utils/dateTranslator';
 
 import { GoalStatus, GoalStatusStringtoType, ISearchGoal } from '../../interfaces/interfaces';
 
-import { detailGoalId } from '../../recoil/goalsAtoms';
-
 interface GroupGoalCardProps {
   goal: ISearchGoal;
   goalClickHandler: (goalId: number) => void;
@@ -19,10 +17,8 @@ interface GroupGoalCardProps {
 
 const GroupGoalCard = ({ goal, goalClickHandler }: GroupGoalCardProps) => {
   const status = GoalStatusStringtoType(goal.status);
-  const saveGoalId = useSetRecoilState(detailGoalId);
 
   const handleDetailGoal = () => {
-    saveGoalId(goal.goalId);
     goalClickHandler(goal.goalId);
   };
 

--- a/src/components/goal/ScrollPaginationGoals.tsx
+++ b/src/components/goal/ScrollPaginationGoals.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Alert from '../common/alert/Alert';
+import LoadingMsg from '../common/elem/LoadingMsg';
+import ErrorMsg from '../common/elem/ErrorMsg';
+import GroupGoalCard from './GroupGoalCard';
+
+import { ISearchGoal } from '../../interfaces/interfaces';
+
+interface scrollPaginationGoalsProps {
+  isLoading: boolean;
+  isError: boolean;
+  emptyMsg: string;
+  goals: Array<ISearchGoal>;
+  goalClickHandler: (goalId: number) => void;
+}
+
+const ScrollPaginationGoals = ({
+  isLoading,
+  isError,
+  emptyMsg,
+  goals,
+  goalClickHandler,
+}: scrollPaginationGoalsProps) => {
+  if (isLoading && goals.length === 0)
+    return (
+      <Alert showBgColor={true}>
+        <LoadingMsg />
+      </Alert>
+    );
+
+  if (isError && goals.length === 0)
+    <Alert showBgColor={true}>
+      <ErrorMsg />
+    </Alert>;
+
+  return (
+    <>
+      {goals.length === 0 ? (
+        <EmptyData>
+          <InfoText>{emptyMsg}</InfoText>
+        </EmptyData>
+      ) : (
+        goals.map((goal) => (
+          <GroupGoalCard key={goal.goalId} goal={goal} goalClickHandler={() => goalClickHandler(goal.goalId)} />
+        ))
+      )}
+      {isLoading ? (
+        <Alert showBgColor={true}>
+          <LoadingMsg />
+        </Alert>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+};
+
+const EmptyData = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 150px;
+  background-color: white;
+  border-radius: 12px;
+  border: 1px solid ${(props) => props.theme.gray300};
+`;
+
+const InfoText = styled.div`
+  text-align: center;
+  font: ${(props) => props.theme.captionC1};
+  color: ${(props) => props.theme.primary400};
+  line-height: 150%;
+  white-space: pre-wrap;
+`;
+
+export default ScrollPaginationGoals;

--- a/src/components/goal/lookup/GroupGoals.tsx
+++ b/src/components/goal/lookup/GroupGoals.tsx
@@ -1,77 +1,52 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import React, { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
-import Alert from '../../common/alert/Alert';
-import LoadingMsg from '../../common/elem/LoadingMsg';
-import ErrorMsg from '../../common/elem/ErrorMsg';
-import GroupGoalCard from '../GroupGoalCard';
+import ScrollPaginationGoals from '../ScrollPaginationGoals';
 
 import useGoalLookupData from '../../../hooks/useGoalLookupData';
+import useSaveScroll from '../../../hooks/useSaveScroll';
 
-import { detailGoalId, groupGoals, isSearchGoalLastPage, searchGoalLastUpdate } from '../../../recoil/goalsAtoms';
-import { useNavigate } from 'react-router-dom';
+import { groupGoals, isSearchGoalLastPage, searchGoalLastUpdate, scrollPosition } from '../../../recoil/goalsAtoms';
 
 const GroupGoals = () => {
   const [cursor, setCursor] = useState<number>(0);
   const savedLookupGoals = useRecoilValue(groupGoals);
   const savedIsLastPage = useRecoilValue(isSearchGoalLastPage);
   const savedLastUpdate = useRecoilValue(searchGoalLastUpdate);
-  const savedGoalId = useRecoilValue(detailGoalId);
   const { isLoading, isError, goals, mutate } = useGoalLookupData({ initVal: savedLookupGoals });
-
   useEffect(() => {
     if (!savedIsLastPage) mutate(cursor);
   }, [cursor]);
 
-  const scrollBoxRef = useRef<HTMLDivElement>(null);
+  const { scrollBoxRef, handleGoalClick, handleSaveScroll } = useSaveScroll();
   const isScrollBottom = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
     if (Math.trunc(e.currentTarget.scrollHeight - e.currentTarget.scrollTop) === e.currentTarget.clientHeight) {
       setCursor(goals[goals.length - 1].goalId);
-      localStorage.setItem('scrollTop', String(e.currentTarget.scrollTop));
+      handleSaveScroll(e.currentTarget.clientHeight);
     }
   };
 
+  const savedScrollPosition = useRecoilValue(scrollPosition);
   useEffect(() => {
-    if (!scrollBoxRef.current) return;
-    const scrollTop = localStorage.getItem('scrollTop');
-    scrollBoxRef.current.scrollTop = Number(scrollTop);
-  }, [goals]);
-
-  const detailGoalRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!detailGoalRef.current) return;
-    detailGoalRef.current.scrollIntoView();
-  }, [detailGoalRef.current]);
-
-  const [routeGoalId, setRouteGoalId] = useState(0);
-  const navigate = useNavigate();
-  useEffect(() => {
-    if (routeGoalId !== 0) return navigate(`/goals/${routeGoalId}`);
-    saveGoalId(0);
-  }, [routeGoalId]);
-
-  const saveGoalId = useSetRecoilState(detailGoalId);
-  useEffect(() => {
-    if (
-      (savedLookupGoals.length === 1 && savedLookupGoals[0].goalId === 0) ||
-      new Date().getTime() - savedLastUpdate.getTime() > 30000
-    ) {
-      return setCursor(0);
+    if (savedLookupGoals.length === 0 || new Date().getTime() - savedLastUpdate.getTime() > 30000) {
+      setCursor(0);
+      if (!scrollBoxRef.current) return;
+      scrollBoxRef.current.scrollTop = 0;
+    } else {
+      setCursor(savedLookupGoals[savedLookupGoals.length - 1].goalId);
     }
-
-    setCursor(savedLookupGoals[savedLookupGoals.length - 1].goalId);
   }, []);
 
-  const [topContentHeight, setTopContentHeight] = useState<number>(0);
-  const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (!ref.current) return;
-    setTopContentHeight(ref.current.clientHeight);
-  }, [ref.current]);
+    if (!isLoading && goals.length !== 0) {
+      if (!scrollBoxRef.current) return;
+      scrollBoxRef.current.scrollTop = savedScrollPosition;
+    }
+  }, [isLoading, goals, scrollBoxRef.current?.scrollHeight]);
 
   return (
-    <BottomContent topContentHeight={topContentHeight}>
+    <Wrapper>
       <TitleBox>
         <SubTitle>목표</SubTitle>
       </TitleBox>
@@ -80,40 +55,26 @@ const GroupGoals = () => {
         onScroll={(e) => {
           if (!savedIsLastPage) isScrollBottom(e);
         }}>
-        {isLoading ? (
-          <Alert showBgColor={true}>
-            <LoadingMsg />
-          </Alert>
-        ) : isError ? (
-          <Alert showBgColor={true}>
-            <ErrorMsg />
-          </Alert>
-        ) : (
-          <>
-            {goals.length === 0 ? (
-              <EmptyData>
-                <InfoText>{`아직 마감 임박인 목표가 없습니다.\n첫번째 목표를 추가해보세요!`}</InfoText>
-              </EmptyData>
-            ) : (
-              goals.map((goal) => {
-                if (goal.goalId === savedGoalId) {
-                  return (
-                    <div key={goal.goalId} ref={detailGoalRef}>
-                      <GroupGoalCard goal={goal} goalClickHandler={() => setRouteGoalId(goal.goalId)} />
-                    </div>
-                  );
-                }
-                return (
-                  <GroupGoalCard key={goal.goalId} goal={goal} goalClickHandler={() => setRouteGoalId(goal.goalId)} />
-                );
-              })
-            )}
-          </>
-        )}
+        <ScrollPaginationGoals
+          isLoading={isLoading}
+          isError={isError}
+          emptyMsg={`현재 모집 중인 목표가 없습니다.\n그룹 목표를 추가해보세요!`}
+          goals={goals}
+          goalClickHandler={handleGoalClick}
+        />
       </GoalCardsWrapper>
-    </BottomContent>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+`;
 
 const TitleBox = styled.div`
   padding: 0 22px;
@@ -127,16 +88,6 @@ const SubTitle = styled.div`
   font: ${(props) => props.theme.paragraphsP3M};
 `;
 
-const BottomContent = styled.div<{ topContentHeight: number }>`
-  padding-top: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 100%;
-  height: calc(100% - ${(props) => props.topContentHeight + 20}px);
-  overflow: hidden;
-`;
-
 const GoalCardsWrapper = styled.div`
   padding: 10px 22px;
   display: flex;
@@ -145,26 +96,6 @@ const GoalCardsWrapper = styled.div`
   width: calc(100% - 44px);
   height: calc(100% - 20px);
   overflow-y: auto;
-`;
-
-const EmptyData = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 150px;
-  background-color: white;
-  border-radius: 12px;
-  border: 1px solid ${(props) => props.theme.gray300};
-`;
-
-const InfoText = styled.div`
-  text-align: center;
-  font: ${(props) => props.theme.captionC1};
-  color: ${(props) => props.theme.primary400};
-  line-height: 150%;
-  white-space: pre-wrap;
 `;
 
 export default GroupGoals;

--- a/src/components/goal/search/SearchResults.tsx
+++ b/src/components/goal/search/SearchResults.tsx
@@ -1,26 +1,29 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import Info from '../../common/alert/Info';
-import GroupGoalCard from '../GroupGoalCard';
-import Alert from '../../common/alert/Alert';
-import LoadingMsg from '../../common/elem/LoadingMsg';
-import ErrorMsg from '../../common/elem/ErrorMsg';
 
 import useSearchGoalsData from '../../../hooks/useSearchGoalsData';
+import useSaveScroll from '../../../hooks/useSaveScroll';
 
-import { ISearchFilter } from '../../../interfaces/interfaces';
-
-import { detailGoalId, groupGoals, isSearchGoalLastPage, searchGoalLastUpdate } from '../../../recoil/goalsAtoms';
-import { useNavigate } from 'react-router-dom';
+import {
+  groupGoals,
+  isSearchGoalLastPage,
+  searchGoalLastUpdate,
+  scrollPosition,
+  cursor,
+  goalId,
+  searchFilters,
+} from '../../../recoil/goalsAtoms';
+import ScrollPaginationGoals from '../ScrollPaginationGoals';
 
 interface SearchResultsProps {
-  params: ISearchFilter;
   totalCntHandler: (totalCnt: number) => void;
 }
 
-const SearchResults = ({ params, totalCntHandler }: SearchResultsProps) => {
+const SearchResults = ({ totalCntHandler }: SearchResultsProps) => {
+  const params = useRecoilValue(searchFilters);
   const savedSearchGoals = useRecoilValue(groupGoals);
   const savedIsLastPage = useRecoilValue(isSearchGoalLastPage);
   const savedLastUpdate = useRecoilValue(searchGoalLastUpdate);
@@ -36,12 +39,14 @@ const SearchResults = ({ params, totalCntHandler }: SearchResultsProps) => {
   // cursor is last goal's sorted type value (ex. amount, period, member(=headCount))
   // cursor is 0 on goal's sorted type is none
   // goalId is search result's last goal's goalId
-  const [cursor, setCursor] = useState(0);
-  const [goalId, setGoalId] = useState(0);
+  const savedCursor = useRecoilValue(cursor);
+  const savedGoalId = useRecoilValue(goalId);
   useEffect(() => {
-    if (!savedIsLastPage) searchGoals({ ...params, cursor, goalId });
-  }, [goalId]);
+    if (!savedIsLastPage) searchGoals({ ...params, cursor: savedCursor, goalId: savedGoalId });
+  }, [savedCursor, savedGoalId]);
 
+  const setCursor = useSetRecoilState(cursor);
+  const setGoalId = useSetRecoilState(goalId);
   useEffect(() => {
     setCursor(0);
     setGoalId(0);
@@ -53,14 +58,14 @@ const SearchResults = ({ params, totalCntHandler }: SearchResultsProps) => {
     totalCntHandler(totalCnt);
   }, [totalCnt]);
 
-  const scrollBoxRef = useRef<HTMLDivElement>(null);
+  const { scrollBoxRef, handleGoalClick, handleSaveScroll } = useSaveScroll();
   const isScrollBottom = () => {
     if (!scrollBoxRef.current) return;
     if (
       Math.trunc(scrollBoxRef.current.scrollHeight - scrollBoxRef.current.scrollTop) ===
       scrollBoxRef.current.clientHeight
     ) {
-      localStorage.setItem('scrollTop', String(scrollBoxRef.current.scrollTop));
+      handleSaveScroll(scrollBoxRef.current.clientHeight);
       setGoalId(searchResult[searchResult.length - 1].goalId);
       switch (params.sorted) {
         case 'amount':
@@ -75,35 +80,32 @@ const SearchResults = ({ params, totalCntHandler }: SearchResultsProps) => {
     }
   };
 
+  const savedScrollPosition = useRecoilValue(scrollPosition);
   useEffect(() => {
-    if (!scrollBoxRef.current) return;
-    if (goalId === 0) return localStorage.setItem('scrollTop', '0');
-    const scrollTop = localStorage.getItem('scrollTop');
-    scrollBoxRef.current.scrollTop = Number(scrollTop);
-  }, [searchGoals]);
+    if (!isLoading && searchResult.length !== 0) {
+      if (!scrollBoxRef.current) return;
+      if (savedGoalId === 0) return handleSaveScroll(0);
+      scrollBoxRef.current.scrollTop = savedScrollPosition;
+    }
+  }, [searchResult, scrollBoxRef.current?.scrollHeight]);
 
-  const savedGoalId = useRecoilValue(detailGoalId);
-  const goalRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (!goalRef.current) return;
-    goalRef.current.scrollIntoView();
-  }, [goalRef.current]);
-
-  const [routeGoalId, setRoutGoalId] = useState(0);
-  const navigate = useNavigate();
-  useEffect(() => {
-    if (routeGoalId !== 0) return navigate(`/goals/${routeGoalId}`);
-    saveGoalId(0);
-  }, [routeGoalId]);
-
-  const saveGoalId = useSetRecoilState(detailGoalId);
-  useEffect(() => {
-    if (
-      (savedSearchGoals.length === 1 && savedSearchGoals[0].goalId === 0) ||
-      new Date().getTime() - savedLastUpdate.getTime() > 30000
-    ) {
+    if (savedSearchGoals.length === 0 || new Date().getTime() - savedLastUpdate.getTime() > 30000) {
       setCursor(0);
       setGoalId(0);
+      handleSaveScroll(0);
+    } else {
+      setGoalId(savedSearchGoals[savedSearchGoals.length - 1].goalId);
+      switch (params.sorted) {
+        case 'amount':
+          return setCursor(savedSearchGoals[savedSearchGoals.length - 1].amount);
+        case 'period':
+          return setCursor(savedSearchGoals[savedSearchGoals.length - 1].period);
+        case 'member':
+          return setCursor(savedSearchGoals[savedSearchGoals.length - 1].headCount);
+        default:
+          return setCursor(0);
+      }
     }
   }, []);
 
@@ -131,39 +133,13 @@ const SearchResults = ({ params, totalCntHandler }: SearchResultsProps) => {
       onScroll={() => {
         if (!savedIsLastPage) isScrollBottom();
       }}>
-      {searchResult.length === 0 ? (
-        <EmptyData>
-          <InfoText>{`검색 결과가 없습니다.\n검색 결과에 알맞는 첫번째 목표를 추가해보세요!`}</InfoText>
-        </EmptyData>
-      ) : (
-        searchResult.map((goal) => {
-          if (goal.goalId === savedGoalId)
-            return (
-              <div ref={goalRef} key={goal.goalId}>
-                <GroupGoalCard goal={goal} goalClickHandler={() => setRoutGoalId(goal.goalId)} />
-              </div>
-            );
-          return (
-            <div key={goal.goalId}>
-              <GroupGoalCard goal={goal} goalClickHandler={() => setRoutGoalId(goal.goalId)} />
-            </div>
-          );
-        })
-      )}
-      {searchResult.length !== 0 && isLoading ? (
-        <Alert showBgColor={false}>
-          <LoadingMsg />
-        </Alert>
-      ) : (
-        <></>
-      )}
-      {searchResult.length !== 0 && isError ? (
-        <Alert showBgColor={false}>
-          <ErrorMsg />
-        </Alert>
-      ) : (
-        <></>
-      )}
+      <ScrollPaginationGoals
+        isLoading={isLoading}
+        isError={isError}
+        emptyMsg={`검색 결과가 없습니다.\n검색 결과에 알맞는 첫번째 목표를 추가해보세요!`}
+        goals={searchResult}
+        goalClickHandler={handleGoalClick}
+      />
     </GoalCardsWrapper>
   );
 };
@@ -184,26 +160,6 @@ const GoalCardsWrapper = styled.div`
   width: calc(100% - 44px);
   height: calc(100% - 40px);
   overflow-y: auto;
-`;
-
-const EmptyData = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 150px;
-  background-color: white;
-  border-radius: 12px;
-  border: 1px solid ${(props) => props.theme.gray300};
-`;
-
-const InfoText = styled.div`
-  text-align: center;
-  font: ${(props) => props.theme.captionC1};
-  color: ${(props) => props.theme.primary400};
-  line-height: 150%;
-  white-space: pre-wrap;
 `;
 
 export default SearchResults;

--- a/src/hooks/useSaveScroll.tsx
+++ b/src/hooks/useSaveScroll.tsx
@@ -1,0 +1,30 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+
+import { scrollPosition } from '../recoil/goalsAtoms';
+
+const useSaveScroll = () => {
+  const scrollBoxRef = useRef<HTMLDivElement>(null);
+  const saveScrollPosition = useSetRecoilState(scrollPosition);
+  const [isScrollSaved, setIsScrollSaved] = useState(false);
+  const [goalId, setGoalId] = useState(0);
+  const handleGoalClick = (goalId: number) => {
+    setGoalId(goalId);
+    handleSaveScroll(scrollBoxRef.current ? scrollBoxRef.current.scrollTop : 0);
+    setIsScrollSaved(true);
+  };
+
+  const handleSaveScroll = (scrollPosition: number) => {
+    saveScrollPosition(scrollPosition);
+  };
+
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (isScrollSaved) navigate(`/goals/${goalId}`);
+  }, [isScrollSaved]);
+
+  return { scrollBoxRef, handleGoalClick, handleSaveScroll };
+};
+
+export default useSaveScroll;

--- a/src/pages/DetailUser.tsx
+++ b/src/pages/DetailUser.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import UserDetailProfile from '../components/user/UserDetailProfile';
@@ -13,13 +13,8 @@ import { userId } from '../recoil/userAtoms';
 
 import RouteChangeTracker from '../shared/RouteChangeTracker';
 import AddGoalBtn from '../components/common/elem/btn/AddGoalBtn';
-import { detailGoalId } from '../recoil/goalsAtoms';
 
 const DetailUser = () => {
-  const setGoalId = useSetRecoilState(detailGoalId);
-  useEffect(() => {
-    setGoalId(0);
-  }, []);
   RouteChangeTracker();
   const { id } = useParams();
   if (!id) return <>잘못된 아이디 값입니다</>;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,7 +11,6 @@ import ErrorMsg from '../components/common/elem/ErrorMsg';
 import AddGoalBtn from '../components/common/elem/btn/AddGoalBtn';
 
 import { isGuideDone, userId } from '../recoil/userAtoms';
-import { detailGoalId } from '../recoil/goalsAtoms';
 
 import useBanksData from '../hooks/useBanksData';
 import useUserGoalsData from '../hooks/useUserGoalsData';
@@ -22,13 +21,11 @@ import RouteChangeTracker from '../shared/RouteChangeTracker';
 import { GoalStatus, GoalStatusStringtoType } from '../interfaces/interfaces';
 
 const Home = () => {
-  const setGoalId = useSetRecoilState(detailGoalId);
   const { home } = useRecoilValue(isGuideDone);
   const [showGuideUI, setShowGuideUI] = useState(false);
   useEffect(() => {
     const isNewComer = localStorage.getItem('isNewComer') === 'true' ? true : false;
     if (isNewComer && !home) setShowGuideUI(true);
-    setGoalId(0);
   }, []);
 
   const setIsGuideDone = useSetRecoilState(isGuideDone);
@@ -40,7 +37,6 @@ const Home = () => {
   RouteChangeTracker();
   useBanksData();
   const { id } = useRecoilValue(userId);
-
   const { isLoading, isError, goals } = useUserGoalsData({ getUserId: Number(id) });
   useBadgesData();
 

--- a/src/pages/SelectGoalType.tsx
+++ b/src/pages/SelectGoalType.tsx
@@ -1,10 +1,7 @@
-import React, { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
+import React from 'react';
 import styled from 'styled-components';
 
 import TypeSelect from '../components/goal/post/TypeSelectSection';
-
-import { detailGoalId } from '../recoil/goalsAtoms';
 
 export enum GoalType {
   group,
@@ -13,11 +10,6 @@ export enum GoalType {
 }
 
 const SelectGoalType = () => {
-  const setGoalId = useSetRecoilState(detailGoalId);
-  useEffect(() => {
-    setGoalId(0);
-  }, []);
-
   return (
     <Wrapper>
       <TypeSelect />

--- a/src/recoil/goalsAtoms.ts
+++ b/src/recoil/goalsAtoms.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
-import { IGoalDetail, IPostGoal, ISearchFilter, ISearchGoal, SortType, StatusType } from '../interfaces/interfaces';
+import { IGoalDetail, IPostGoal, ISearchFilter, ISearchGoal } from '../interfaces/interfaces';
 
 const { persistAtom } = recoilPersist();
 
@@ -70,26 +70,22 @@ export const searchFilters = atom<ISearchFilter>({
 
 export const groupGoals = atom<Array<ISearchGoal>>({
   key: 'groupGoals',
-  default: [
-    {
-      userId: 0,
-      goalId: 0,
-      nickname: '',
-      amount: 0,
-      curCount: 0,
-      headCount: 0,
-      startDate: new Date(),
-      endDate: new Date(),
-      period: 0,
-      status: 'proceeding',
-      title: '',
-      hashTag: [],
-      emoji: '',
-      description: '',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-  ],
+  default: [],
+});
+
+export const scrollPosition = atom({
+  key: 'scrollPosition',
+  default: 0,
+});
+
+export const cursor = atom({
+  key: 'cursor',
+  default: 0,
+});
+
+export const goalId = atom({
+  key: 'goalId',
+  default: 0,
 });
 
 export const isSearchGoalLastPage = atom<boolean>({
@@ -100,9 +96,4 @@ export const isSearchGoalLastPage = atom<boolean>({
 export const searchGoalLastUpdate = atom<Date>({
   key: 'searchGoalLastUpdate',
   default: new Date(),
-});
-
-export const detailGoalId = atom<number>({
-  key: 'detailGoalId',
-  default: 0,
 });


### PR DESCRIPTION
# 스크롤 위치 복원 기능 버그 수정 (#223)
## 변경 사항
* `src/components/goal/ScrollPaginationGoals.tsx`: 스크롤 element의 자식 UI(view) 만 담당하는 컴포넌트 분리
* `src/hooks/useSaveScroll.tsx`: 상세 페이지 이동 전, 스크롤 위치를 전역 상태로 저장하는 로직을 담당하는 훅 구현
* `src/components/goal/lookup/GroupGoals.tsx`: 상세 페이지 이동 요소의 `goalId` 값이 아닌 스크롤 element의 스크롤 위치값을 저장 및 목표 조회 시 전역 상태로 저장된 스크롤 위치값을 사용하도록 수정.
* `src/components/goal/search/SearchResults.tsx`: 
  * 상세 페이지 이동 요소의 `goalId` 값이 아닌 스크롤 element의 스크롤 위치값을 저장 및 목표 조회 시 전역 상태로 저장된 스크롤 위치값을 사용.
  * 검색 시 사용된 `cursor`, `goalId` 값도 전역 상태로 저장해 초기화 되지 않도록 수정.
* `src/recoil/goalsAtoms.ts`: 상세 페이지 이동한 요소의 `goalId` 저장 삭제, 검색 페이지의 `cursor`, `goalId`, 스크롤 위치 값을 저장하도록 수정.
* 그 외: 페이지 이동 시, 상세 페이지 이동한 요소의 `goalId`값을 초기화 하는 로직 제거